### PR TITLE
fix(swap): change order of address parsing

### DIFF
--- a/packages/shared/src/node-apis/broker.ts
+++ b/packages/shared/src/node-apis/broker.ts
@@ -77,7 +77,7 @@ const requestValidators = {
 const responseValidators = {
   requestSwapDepositAddress: z
     .object({
-      address: z.union([hexString, btcAddress(), dotAddress]),
+      address: z.union([dotAddress, hexString, btcAddress()]),
       expiry_block: z.number(),
       issued_block: z.number(),
       channel_id: z.number(),


### PR DESCRIPTION
The address we receive from the broker is in the format of `0x0df387bef5a3a7f07e72cd3b43fd5ec93e4598c6069dc047d1ed65660235e973`. This is obviously a hex string so the parsing stops with `hexString`. By moving `dotAddress` to the front, we ensure it will be properly encoded when inserted into the db.