### PR TITLE
chore: remove expiry_block from deposit address created events

### DIFF
--- a/packages/cli/src/commands/cliRequestSwapDepositAddress.ts
+++ b/packages/cli/src/commands/cliRequestSwapDepositAddress.ts
@@ -71,7 +71,6 @@ export default async function cliRequestSwapDepositAddress(
 
   console.log(`Deposit address: ${result.address}`);
   console.log(`Issued block: ${result.issuedBlock}`);
-  console.log(`Expiry block: ${result.expiryBlock}`);
   console.log(`Channel ID: ${result.channelId}`);
 
   await client.close();

--- a/packages/shared/src/node-apis/__tests__/broker.test.ts
+++ b/packages/shared/src/node-apis/__tests__/broker.test.ts
@@ -60,7 +60,6 @@ describe(BrokerClient.prototype.requestSwapDepositAddress, () => {
         jsonrpc: '2.0',
         result: {
           address: '0x1234567890',
-          expiry_block: 100,
           issued_block: 50,
           channel_id: 200,
         },
@@ -69,7 +68,6 @@ describe(BrokerClient.prototype.requestSwapDepositAddress, () => {
 
     await expect(resultPromise).resolves.toStrictEqual({
       address: '0x1234567890',
-      expiryBlock: 100,
       issuedBlock: 50,
       channelId: 200n,
     });
@@ -98,7 +96,6 @@ describe(BrokerClient.prototype.requestSwapDepositAddress, () => {
         jsonrpc: '2.0',
         result: {
           address: '0x1234567890',
-          expiry_block: 100,
           issued_block: 50,
           channel_id: 200,
         },
@@ -122,7 +119,6 @@ describe(BrokerClient.prototype.requestSwapDepositAddress, () => {
     });
     await expect(resultPromise).resolves.toStrictEqual({
       address: '0x1234567890',
-      expiryBlock: 100,
       issuedBlock: 50,
       channelId: 200n,
     });

--- a/packages/shared/src/node-apis/broker.ts
+++ b/packages/shared/src/node-apis/broker.ts
@@ -80,13 +80,11 @@ const responseValidators = {
   requestSwapDepositAddress: z
     .object({
       address: z.union([dotAddress, hexString, btcAddress()]),
-      expiry_block: z.number(),
       issued_block: z.number(),
       channel_id: z.number(),
     })
-    .transform(({ address, expiry_block, issued_block, channel_id }) => ({
+    .transform(({ address, issued_block, channel_id }) => ({
       address,
-      expiryBlock: expiry_block,
       issuedBlock: issued_block,
       channelId: BigInt(channel_id),
     })),

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -42,7 +42,6 @@ export type PostSwapResponse = {
   id: string;
   depositAddress: string;
   issuedBlock: number;
-  expiryBlock: number;
 };
 
 export const quoteResponseSchema = z.union([

--- a/packages/swap/prisma/migrations/20230926114115_remove_expiry_block/migration.sql
+++ b/packages/swap/prisma/migrations/20230926114115_remove_expiry_block/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `expiryBlock` on the `SwapDepositChannel` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."SwapDepositChannel" DROP COLUMN "expiryBlock";

--- a/packages/swap/prisma/schema.prisma
+++ b/packages/swap/prisma/schema.prisma
@@ -44,7 +44,6 @@ model SwapDepositChannel {
   expectedDepositAmount Decimal  @db.Decimal(30, 0)
   destAsset             Asset
   destAddress           String
-  expiryBlock           Int
   issuedBlock           Int
   createdAt             DateTime @default(now())
   swaps                 Swap[]

--- a/packages/swap/src/__tests__/processBlocks.test.ts
+++ b/packages/swap/src/__tests__/processBlocks.test.ts
@@ -14,7 +14,6 @@ describe(processBlocks, () => {
       data: {
         depositAddress: '5CGLqaFMheyVcsXz6QEtjtSAi6RcXFaEDJKvovgCdPiZhw11',
         issuedBlock: 100,
-        expiryBlock: 200,
         channelId: 250n,
         srcChain: 'Polkadot',
         srcAsset: 'DOT',

--- a/packages/swap/src/event-handlers/__tests__/batchSwap.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/batchSwap.test.ts
@@ -23,7 +23,6 @@ const swapDepositAddressReadyEvent = {
   name: 'Swapping.SwapDepositAddressReady',
   args: {
     channelId: '3',
-    expiryBlock: 2,
     sourceAsset: {
       __kind: 'Eth',
     },
@@ -207,7 +206,6 @@ describe('batch swap flow', () => {
           swapDepositAddressReadyEvent.args.destinationAsset.__kind,
         ),
         destAddress: swapDepositAddressReadyEvent.args.destinationAddress.value,
-        expiryBlock: swapDepositAddressReadyEvent.args.expiryBlock,
         issuedBlock: 0,
       },
     });

--- a/packages/swap/src/event-handlers/__tests__/ccmSwap.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/ccmSwap.test.ts
@@ -24,7 +24,6 @@ const swapDepositAddressReadyEvent = {
   name: 'Swapping.SwapDepositAddressReady',
   args: {
     channelId: '6',
-    expiryBlock: 200,
     sourceAsset: { __kind: 'Dot' },
     depositAddress: {
       value:
@@ -239,7 +238,6 @@ describe('batch swap flow', () => {
           swapDepositAddressReadyEvent.args.destinationAsset.__kind,
         ),
         destAddress: swapDepositAddressReadyEvent.args.destinationAddress.value,
-        expiryBlock: swapDepositAddressReadyEvent.args.expiryBlock,
         issuedBlock: 0,
       },
     });

--- a/packages/swap/src/event-handlers/__tests__/swapScheduled.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/swapScheduled.test.ts
@@ -84,24 +84,6 @@ describe(swapScheduled, () => {
       });
     });
 
-    // The expiry is now on the ingress-egress side.
-    // it('does not store a new swap if the deposit channel is expired', async () => {
-    //   await prisma.swapDepositChannel.update({
-    //     where: { id: dotSwapDepositChannel.id },
-    //     data: { expiryBlock: -1 },
-    //   });
-
-    //   await prisma.$transaction(async (client) => {
-    //     await swapScheduled({
-    //       prisma: client,
-    //       block: swapScheduledDotDepositChannelMock.block,
-    //       event: swapScheduledDotDepositChannelMock.eventContext.event as any,
-    //     });
-    //   });
-
-    //   expect(await prisma.swap.findFirst()).toBeNull();
-    // });
-
     it('does not store a new swap if the deposit channel is not found', async () => {
       await prisma.swapDepositChannel.update({
         where: { id: dotSwapDepositChannel.id },

--- a/packages/swap/src/event-handlers/__tests__/swapScheduled.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/swapScheduled.test.ts
@@ -84,22 +84,23 @@ describe(swapScheduled, () => {
       });
     });
 
-    it('does not store a new swap if the deposit channel is expired', async () => {
-      await prisma.swapDepositChannel.update({
-        where: { id: dotSwapDepositChannel.id },
-        data: { expiryBlock: -1 },
-      });
+    // The expiry is now on the ingress-egress side.
+    // it('does not store a new swap if the deposit channel is expired', async () => {
+    //   await prisma.swapDepositChannel.update({
+    //     where: { id: dotSwapDepositChannel.id },
+    //     data: { expiryBlock: -1 },
+    //   });
 
-      await prisma.$transaction(async (client) => {
-        await swapScheduled({
-          prisma: client,
-          block: swapScheduledDotDepositChannelMock.block,
-          event: swapScheduledDotDepositChannelMock.eventContext.event as any,
-        });
-      });
+    //   await prisma.$transaction(async (client) => {
+    //     await swapScheduled({
+    //       prisma: client,
+    //       block: swapScheduledDotDepositChannelMock.block,
+    //       event: swapScheduledDotDepositChannelMock.eventContext.event as any,
+    //     });
+    //   });
 
-      expect(await prisma.swap.findFirst()).toBeNull();
-    });
+    //   expect(await prisma.swap.findFirst()).toBeNull();
+    // });
 
     it('does not store a new swap if the deposit channel is not found', async () => {
       await prisma.swapDepositChannel.update({

--- a/packages/swap/src/event-handlers/__tests__/utils.ts
+++ b/packages/swap/src/event-handlers/__tests__/utils.ts
@@ -24,7 +24,6 @@ export const createDepositChannel = (
       depositAddress: ETH_ADDRESS,
       destAddress: DOT_ADDRESS,
       expectedDepositAmount: '10000000000',
-      expiryBlock: 200,
       issuedBlock: 100,
       ...data,
       createdAt: new Date(1690556052834),

--- a/packages/swap/src/event-handlers/swapScheduled.ts
+++ b/packages/swap/src/event-handlers/swapScheduled.ts
@@ -62,7 +62,6 @@ export default async function swapScheduled({
       where: {
         srcAsset: sourceAsset,
         depositAddress,
-        expiryBlock: { gte: block.height },
         issuedBlock: { lte: block.height },
       },
     });

--- a/packages/swap/src/routes/__tests__/swap.test.ts
+++ b/packages/swap/src/routes/__tests__/swap.test.ts
@@ -556,12 +556,10 @@ describe('server', () => {
       ],
     ])('creates a new swap deposit channel', async (requestBody) => {
       const issuedBlock = 123;
-      const expiryBlock = 200;
       const channelId = 200n;
       const address = 'THE_INGRESS_ADDRESS';
       jest.spyOn(RpcClient.prototype, 'sendRequest').mockResolvedValueOnce({
         address,
-        expiryBlock,
         issuedBlock,
         channelId,
       });
@@ -580,7 +578,6 @@ describe('server', () => {
         depositAddress: address,
         destAsset: requestBody.destAsset,
         destAddress: requestBody.destAddress,
-        expiryBlock,
         issuedBlock,
         channelId,
         createdAt: expect.any(Date),
@@ -593,7 +590,6 @@ describe('server', () => {
         id: '123-Ethereum-200',
         depositAddress: address,
         issuedBlock,
-        expiryBlock,
       });
     });
 

--- a/packages/swap/src/routes/swap.ts
+++ b/packages/swap/src/routes/swap.ts
@@ -215,7 +215,7 @@ router.post(
 
     const { destChain, ...rest } = payload;
 
-    const { issuedBlock, expiryBlock, srcChain, channelId } =
+    const { issuedBlock, srcChain, channelId } =
       await prisma.swapDepositChannel.create({
         data: {
           ...rest,
@@ -228,7 +228,6 @@ router.post(
       id: `${issuedBlock}-${srcChain}-${channelId}`,
       depositAddress,
       issuedBlock,
-      expiryBlock,
     };
 
     res.json(response);


### PR DESCRIPTION
Not sure I should touch the schema / migrations / tests... 

@niklasnatter said the expiry_block isn't used right now, so removing it from here since we removed it from the event on the backend.

Instead of this, the expiry will be found on the event emitted in the `ingress-egress` pallet, `expires_at`, and this number will be an *external chain* block number. i.e. *not* a SC number. 

The product, however, should use some block a while before this *expires_at* number. (CC @fernandezdavid )