### PR TITLE
fix(swap): [WEB-371] should support expiration times from the past

### DIFF
--- a/packages/swap/src/utils/function.ts
+++ b/packages/swap/src/utils/function.ts
@@ -50,10 +50,7 @@ export function calculateExpiryTime(args: {
     return null;
   }
 
-  const remainingBlocks = Number(expiryBlock - startBlock);
-  if (remainingBlocks < 0) {
-    return null;
-  }
+  const remainingBlocks = Number(expiryBlock - startBlock); // If it is negative, it means the channel has already expired and will return the time from the past
 
   return new Date(Date.now() + remainingBlocks * blockTimeMap[chain] * 1000);
 }


### PR DESCRIPTION
[WEB-371]
- Removed the condition to return null in case of past expiries. It should always return the correct time