### PR TITLE
fix(swap): handle numbers [WEB-717]

### DIFF
--- a/packages/shared/src/__tests__/parsers.test.ts
+++ b/packages/shared/src/__tests__/parsers.test.ts
@@ -61,6 +61,10 @@ describe('dotAddress', () => {
 });
 
 describe('u128', () => {
+  it('handles numbers', () => {
+    expect(u128.parse(123)).toBe(123n);
+  });
+
   it('handles numeric strings', () => {
     expect(u128.parse('123')).toBe(123n);
   });

--- a/packages/shared/src/parsers.ts
+++ b/packages/shared/src/parsers.ts
@@ -70,7 +70,7 @@ export const ethereumAddress = hexString.refine((address) =>
 export const u64 = numericString.transform((arg) => BigInt(arg));
 
 export const u128 = z
-  .union([numericString, hexString])
+  .union([number, z.union([numericString, hexString])])
   .transform((arg) => BigInt(arg));
 
 export const unsignedInteger = z.union([

--- a/packages/shared/src/parsers.ts
+++ b/packages/shared/src/parsers.ts
@@ -70,7 +70,7 @@ export const ethereumAddress = hexString.refine((address) =>
 export const u64 = numericString.transform((arg) => BigInt(arg));
 
 export const u128 = z
-  .union([number, z.union([numericString, hexString])])
+  .union([number, numericString, hexString])
   .transform((arg) => BigInt(arg));
 
 export const unsignedInteger = z.union([


### PR DESCRIPTION
`NumberOrHex` can be serialized into a number if the underlying number is a `u64` and the value is < `Number.MAX_SAFE_INTEGER`