### PR TITLE
docs: Update README.md

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,3 @@
 # @chainflip/sdk
 
 [Docs](https://docs.chainflip.io/integration/swapping-and-aggregation/javascript-sdk/quick-start)
-

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,3 +1,4 @@
 # @chainflip/sdk
 
-[Docs](https://docs.chainflip.io/sdk/)
+[Docs](https://docs.chainflip.io/integration/swapping-and-aggregation/javascript-sdk/quick-start)
+


### PR DESCRIPTION
Updated the hyperlink to point to the "Quick Start" section of the JavaScript SDK documentation on the Chainflip docs site.