### PR TITLE
chore: Export ChainflipId type from sdk package

### DIFF
--- a/packages/sdk/src/swap/index.ts
+++ b/packages/sdk/src/swap/index.ts
@@ -3,9 +3,11 @@ export * from './types';
 export {
   type Chain,
   type Asset,
+  type InternalAsset as ChainflipId,
   type ChainflipNetwork,
   Chains,
   Assets,
+  InternalAssets as ChainflipIds,
   ChainflipNetworks,
+  getInternalAsset as getChainflipId,
 } from '@/shared/enums';
-export { getInternalAsset as getChainflipId } from '@/shared/enums';


### PR DESCRIPTION
Follow up for https://github.com/chainflip-io/chainflip-sdk-monorepo/pull/580