### PR TITLE
fix: Make values in ingress_fees and egress_fees map nullable

### DIFF
--- a/packages/shared/src/rpc/__tests__/index.test.ts
+++ b/packages/shared/src/rpc/__tests__/index.test.ts
@@ -85,7 +85,7 @@ describe('getIngressEgressEnvironment', () => {
           ETH: 0x4563918244f40000n,
           USDC: 0x4563918244f40000n,
           FLIP: 0x4563918244f40000n,
-          USDT: 0n,
+          USDT: null,
         },
         Polkadot: { DOT: 0x4563918244f40000n },
       },
@@ -97,7 +97,7 @@ describe('getIngressEgressEnvironment', () => {
           ETH: 0n,
           FLIP: 0n,
           USDC: 0n,
-          USDT: 0n,
+          USDT: null,
         },
         Polkadot: {
           DOT: 0n,

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -146,8 +146,8 @@ const rename =
 const ingressEgressEnvironment = z
   .object({
     minimum_deposit_amounts: chainAssetMapFactory(numberOrHex, 0),
-    ingress_fees: chainAssetMapFactory(numberOrHex, 0),
-    egress_fees: chainAssetMapFactory(numberOrHex, 0),
+    ingress_fees: chainAssetMapFactory(numberOrHex.nullable(), null),
+    egress_fees: chainAssetMapFactory(numberOrHex.nullable(), null),
     witness_safety_margins: chainNumberNullableMap,
     egress_dust_limits: chainAssetMapFactory(numberOrHex, 1),
     // TODO(1.3): remove optional and default value

--- a/packages/shared/src/tests/fixtures.ts
+++ b/packages/shared/src/tests/fixtures.ts
@@ -78,8 +78,8 @@ export const ingressEgressEnvironment = ({
   channelOpeningFee,
 }: {
   minDepositAmount?: string;
-  ingressFee?: string;
-  egressFee?: string;
+  ingressFee?: string | null;
+  egressFee?: string | null;
   minEgressAmount?: string;
   channelOpeningFee?: string;
 } = {}) => ({
@@ -136,8 +136,8 @@ export const environment = ({
 }: {
   maxSwapAmount?: string | null;
   minDepositAmount?: string;
-  ingressFee?: string;
-  egressFee?: string;
+  ingressFee?: string | null;
+  egressFee?: string | null;
   minEgressAmount?: string;
 } = {}) => ({
   id: 1,

--- a/packages/swap/src/event-handlers/swapEgressScheduled.ts
+++ b/packages/swap/src/event-handlers/swapEgressScheduled.ts
@@ -92,7 +92,7 @@ const getEgressFeeAtBlock = async (
     assetConstants[asset],
   );
 
-  return getCachedAssetAmountAtBlock(asset, nativeFee, blockHash);
+  return getCachedAssetAmountAtBlock(asset, nativeFee ?? 0n, blockHash);
 };
 
 /**

--- a/packages/swap/src/routes/quote.ts
+++ b/packages/swap/src/routes/quote.ts
@@ -87,7 +87,7 @@ const quote = (io: Server) => {
       let ingressFee = await getIngressFee(srcChainAsset);
       if (ingressFee == null) {
         throw ServiceError.internalError(
-          `no ingress fee for ${getInternalAsset(srcChainAsset)}`,
+          `could not determine ingress fee for ${getInternalAsset(srcChainAsset)}`,
         );
       }
       if (ingressEgressFeeIsGasAssetAmount) {
@@ -171,7 +171,7 @@ const quote = (io: Server) => {
         let egressFee = await getEgressFee(destChainAsset);
         if (egressFee == null) {
           throw ServiceError.internalError(
-            `no egress fee for ${getInternalAsset(destChainAsset)}`,
+            `could not determine egress fee for ${getInternalAsset(destChainAsset)}`,
           );
         }
         if (ingressEgressFeeIsGasAssetAmount) {

--- a/packages/swap/src/routes/quote.ts
+++ b/packages/swap/src/routes/quote.ts
@@ -85,6 +85,11 @@ const quote = (io: Server) => {
 
       const includedFees: SwapFee[] = [];
       let ingressFee = await getIngressFee(srcChainAsset);
+      if (ingressFee == null) {
+        throw ServiceError.internalError(
+          `no ingress fee for ${getInternalAsset(srcChainAsset)}`,
+        );
+      }
       if (ingressEgressFeeIsGasAssetAmount) {
         ingressFee = await estimateIngressEgressFeeAssetAmount(
           ingressFee,
@@ -164,6 +169,11 @@ const quote = (io: Server) => {
         includedFees.push(...quoteSwapFees);
 
         let egressFee = await getEgressFee(destChainAsset);
+        if (egressFee == null) {
+          throw ServiceError.internalError(
+            `no egress fee for ${getInternalAsset(destChainAsset)}`,
+          );
+        }
         if (ingressEgressFeeIsGasAssetAmount) {
           egressFee = await estimateIngressEgressFeeAssetAmount(
             egressFee,

--- a/packages/swap/src/utils/rpc.ts
+++ b/packages/swap/src/utils/rpc.ts
@@ -44,7 +44,7 @@ export const getWitnessSafetyMargin = async (
 
 export const getIngressFee = async (
   asset: UncheckedAssetAndChain,
-): Promise<bigint> => {
+): Promise<bigint | null> => {
   const environment = await cachedGetEnvironment(rpcConfig);
 
   return readChainAssetValue(environment.ingressEgress.ingressFees, asset);
@@ -52,7 +52,7 @@ export const getIngressFee = async (
 
 export const getEgressFee = async (
   asset: UncheckedAssetAndChain,
-): Promise<bigint> => {
+): Promise<bigint | null> => {
   const environment = await cachedGetEnvironment(rpcConfig);
 
   return readChainAssetValue(environment.ingressEgress.egressFees, asset);


### PR DESCRIPTION
The values are null if the fee cannot be calculated by the backend since https://github.com/chainflip-io/chainflip-backend/pull/4497/files#diff-da69d849254aec2e3c9755396682d6302755145e827801c8d0bbccad22c25c85R269