### PR TITLE
feat(swap): add new pool table and handle event [WEB-1008]

### DIFF
--- a/packages/swap/prisma/migrations/20240424073814_add_boost_pool_table/migration.sql
+++ b/packages/swap/prisma/migrations/20240424073814_add_boost_pool_table/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "public"."BoostPool" (
+    "id" SERIAL NOT NULL,
+    "depositEnabled" BOOLEAN NOT NULL,
+    "withdrawEnabled" BOOLEAN NOT NULL,
+    "boostEnabled" BOOLEAN NOT NULL,
+    "asset" "public"."InternalAsset" NOT NULL,
+    "feeTierPips" INTEGER NOT NULL,
+
+    CONSTRAINT "BoostPool_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BoostPool_asset_feeTierPips_key" ON "public"."BoostPool"("asset", "feeTierPips");

--- a/packages/swap/prisma/schema.prisma
+++ b/packages/swap/prisma/schema.prisma
@@ -276,6 +276,18 @@ model Pool {
   @@schema("public")
 }
 
+model BoostPool {
+  id              Int           @id @default(autoincrement())
+  depositEnabled  Boolean
+  withdrawEnabled Boolean
+  boostEnabled    Boolean
+  asset           InternalAsset
+  feeTierPips     Int
+
+  @@unique([asset, feeTierPips])
+  @@schema("public")
+}
+
 model ChainTracking {
   id             Int      @id @default(autoincrement())
   chain          Chain    @unique

--- a/packages/swap/src/event-handlers/index.ts
+++ b/packages/swap/src/event-handlers/index.ts
@@ -20,6 +20,7 @@ import swapEgressScheduled from './swapEgressScheduled';
 import swapExecuted from './swapExecuted';
 import swapScheduled from './swapScheduled';
 import { networkDepositReceived as networkDepositReceivedV120 } from './v120/networkDepositReceived';
+import { boostPoolCreated } from './v140/boostPoolCreated';
 import { depositFinalised } from './v140/depositFinalised';
 import type { Block, Event } from '../gql/generated/graphql';
 import { buildHandlerMap, getDispatcher } from '../utils/handlers';
@@ -48,6 +49,7 @@ export const events = {
     DepositReceived: 'BitcoinIngressEgress.DepositReceived', // Renamed to DepositFinalised since spec 140
     DepositFinalised: 'BitcoinIngressEgress.DepositFinalised',
     DepositIgnored: 'BitcoinIngressEgress.DepositIgnored',
+    BoostPoolCreated: 'BitcoinIngressEgress.BoostPoolCreated',
   },
   BitcoinBroadcaster: {
     BroadcastSuccess: 'BitcoinBroadcaster.BroadcastSuccess',
@@ -60,6 +62,7 @@ export const events = {
     DepositReceived: 'EthereumIngressEgress.DepositReceived', // Renamed to DepositFinalised since spec 140
     DepositFinalised: 'EthereumIngressEgress.DepositFinalised',
     DepositIgnored: 'EthereumIngressEgress.DepositIgnored',
+    BoostPoolCreated: 'EthereumIngressEgress.BoostPoolCreated',
   },
   ArbitrumIngressEgress: {
     EgressScheduled: 'ArbitrumIngressEgress.EgressScheduled',
@@ -68,6 +71,7 @@ export const events = {
     DepositReceived: 'ArbitrumIngressEgress.DepositReceived', // Renamed to DepositFinalised since spec 140
     DepositFinalised: 'ArbitrumIngressEgress.DepositFinalised',
     DepositIgnored: 'ArbitrumIngressEgress.DepositIgnored',
+    BoostPoolCreated: 'ArbitrumIngressEgress.BoostPoolCreated',
   },
   EthereumBroadcaster: {
     BroadcastSuccess: 'EthereumBroadcaster.BroadcastSuccess',
@@ -84,6 +88,7 @@ export const events = {
     DepositReceived: 'PolkadotIngressEgress.DepositReceived', // Renamed to DepositFinalised since spec 140
     DepositFinalised: 'PolkadotIngressEgress.DepositFinalised',
     DepositIgnored: 'PolkadotIngressEgress.DepositIgnored',
+    BoostPoolCreated: 'PolkadotIngressEgress.BoostPoolCreated',
   },
   PolkadotBroadcaster: {
     BroadcastSuccess: 'PolkadotBroadcaster.BroadcastSuccess',
@@ -170,14 +175,12 @@ const handlers = [
   },
   {
     spec: 114,
-    handlers: [
-      ...Object.values(Chains).flatMap((chain) => [
-        {
-          name: events[`${chain}IngressEgress`].DepositIgnored,
-          handler: depositIgnored(chain),
-        },
-      ]),
-    ],
+    handlers: Object.values(Chains).flatMap((chain) => [
+      {
+        name: events[`${chain}IngressEgress`].DepositIgnored,
+        handler: depositIgnored(chain),
+      },
+    ]),
   },
   {
     spec: 120,
@@ -200,10 +203,16 @@ const handlers = [
   },
   {
     spec: 140,
-    handlers: Object.values(Chains).map((chain) => ({
-      name: events[`${chain}IngressEgress`].DepositFinalised,
-      handler: depositFinalised,
-    })),
+    handlers: Object.values(Chains).flatMap((chain) => [
+      {
+        name: events[`${chain}IngressEgress`].DepositFinalised,
+        handler: depositFinalised,
+      },
+      {
+        name: events[`${chain}IngressEgress`].BoostPoolCreated,
+        handler: boostPoolCreated,
+      },
+    ]),
   },
 ];
 

--- a/packages/swap/src/event-handlers/v140/__tests__/__snapshots__/boostPoolCreated.test.ts.snap
+++ b/packages/swap/src/event-handlers/v140/__tests__/__snapshots__/boostPoolCreated.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`boostPoolCreated handles event by creating a boost pool entry 1`] = `
+{
+  "asset": "Btc",
+  "boostEnabled": true,
+  "depositEnabled": true,
+  "feeTierPips": 10,
+  "id": 1,
+  "withdrawEnabled": true,
+}
+`;

--- a/packages/swap/src/event-handlers/v140/__tests__/boostPoolCreated.test.ts
+++ b/packages/swap/src/event-handlers/v140/__tests__/boostPoolCreated.test.ts
@@ -1,0 +1,34 @@
+import prisma from '@/swap/client';
+import { boostPoolCreated } from '../boostPoolCreated';
+
+describe(boostPoolCreated, () => {
+  beforeEach(async () => {
+    await prisma.$queryRaw`TRUNCATE TABLE "BoostPool" CASCADE`;
+  });
+  it('handles event by creating a boost pool entry', async () => {
+    await prisma.$transaction(async (txClient) => {
+      await boostPoolCreated({
+        prisma: txClient,
+        block: {
+          height: 120,
+          timestamp: 1670337105000,
+        } as any,
+        event: {
+          args: {
+            boostPool: {
+              asset: {
+                chain: 'Bitcoin',
+                asset: 'BTC',
+              },
+              tier: 10,
+            },
+          },
+          name: 'BitcoinIngressEgress.BoostPoolCreated',
+          indexInBlock: 7,
+        },
+      });
+    });
+
+    expect(await prisma.boostPool.findFirst()).toMatchSnapshot();
+  });
+});

--- a/packages/swap/src/event-handlers/v140/boostPoolCreated.ts
+++ b/packages/swap/src/event-handlers/v140/boostPoolCreated.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { assetAndChain, number } from '@/shared/parsers';
+import { screamingSnakeToPascalCase } from '@/shared/strings';
+import { EventHandlerArgs } from '..';
+import { InternalAsset } from '../../client';
+
+const boostPoolCreatedEventSchema = z.object({
+  boostPool: z.object({
+    asset: assetAndChain.transform((chainAsset) => ({
+      ...chainAsset,
+      asset: screamingSnakeToPascalCase(chainAsset.asset),
+    })),
+    tier: number,
+  }),
+});
+
+export const boostPoolCreated = async ({ prisma, event }: EventHandlerArgs) => {
+  const {
+    boostPool: { asset: chainAsset, tier },
+  } = boostPoolCreatedEventSchema.parse(event.args);
+
+  await prisma.boostPool.upsert({
+    create: {
+      asset: chainAsset.asset as InternalAsset,
+      feeTierPips: tier,
+      // safe mode is disabled by default which means pools are active
+      boostEnabled: true,
+      depositEnabled: true,
+      withdrawEnabled: true,
+    },
+    where: {
+      asset_feeTierPips: {
+        asset: chainAsset.asset as InternalAsset,
+        feeTierPips: tier,
+      },
+    },
+    update: {},
+  });
+};


### PR DESCRIPTION
~~These pools will be created with a migration. That means that they will be available on all networks without requiring an extrinsic call.~~

~~For localnets, they will be enabled by default (safe mode flags will be turned on: deposit_enabled, withdraw_enabled, boost_enabled). For public networks, they will be disabled by default and enabled via an extrinsic call (event will be emitted). We will capture this event to update the safe mode flags.~~

~~The approach i am taking is the following:~~
- ~~One off job to initialize the pools based on the environment. If localnet, set flags to true. If pubnet set flags to false.~~
- ~~On testnets, we will rely on an event to update these pools. A follow up PR will introduce the event handler for this~~

Based on the latest discussion, we can expect an event when a boost pool was created.