### PR TITLE
refactor(swap): change log

### DIFF
--- a/packages/swap/src/quoting/Quoter.ts
+++ b/packages/swap/src/quoting/Quoter.ts
@@ -81,7 +81,7 @@ export default class Quoter {
 
         if (!result.success) {
           logger.warn(`received invalid quote response from "${socket.data.marketMaker}"`, {
-            message,
+            quoteResponse: message,
             reason: result.error,
           });
           return;


### PR DESCRIPTION
the winston JSON transport takes the string and adds it to a `message` property, but because we provide a `message` property in the meta object, it merges those together into one string. So instead of seeing the market maker quote response, we just see `received invalid quote response from "cF..." [object Object]`