### PR TITLE
fix(swap): use correct assets

### DIFF
--- a/packages/swap/src/event-handlers/swapScheduled.ts
+++ b/packages/swap/src/event-handlers/swapScheduled.ts
@@ -92,15 +92,13 @@ export default async function swapScheduled({
       return;
     }
 
-    const { srcAsset, destAddress, destAsset, id } = channel;
-
     await prisma.swap.create({
       data: {
         type: swapType.type,
-        swapDepositChannelId: id,
-        srcAsset,
-        destAsset,
-        destAddress,
+        swapDepositChannelId: channel.id,
+        srcAsset: sourceAsset,
+        destAsset: destinationAsset,
+        destAddress: destinationAddress.address,
         ...newSwapData,
       },
     });


### PR DESCRIPTION
For CCM gas swaps that originate from deposit channels, we are saving the assets incorrectly