### PR TITLE
fix(sdk): expose transaction ref from ingress egress tracker in sdk swaps [WEB-1643]

### DIFF
--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -1,0 +1,19 @@
+import * as base58 from '@chainflip/utils/base58';
+import { hexToBytes, reverseBytes } from '@chainflip/utils/bytes';
+import type { HexString } from '@chainflip/utils/types';
+import { Chain } from './enums';
+
+export function formatTxHash(chain: Chain, txHash: string): string;
+export function formatTxHash(chain: Chain, txHash: string | undefined): string | undefined;
+export function formatTxHash(chain: Chain, txHash: string | undefined) {
+  if (!txHash) return txHash;
+
+  switch (chain) {
+    case 'Bitcoin':
+      return reverseBytes(txHash.slice(2));
+    case 'Solana':
+      return base58.encode(hexToBytes(txHash as HexString));
+    default:
+      return txHash;
+  }
+}

--- a/packages/shared/src/node-apis/__tests__/redis.test.ts
+++ b/packages/shared/src/node-apis/__tests__/redis.test.ts
@@ -101,22 +101,54 @@ describe(RedisClient, () => {
           asset: 'ETH',
           deposit_chain_block_height: 1234,
           deposit_details: {
-            tx_hashes: ["0xdeadc0de"]
+            tx_hashes: ['0xdeadc0de'],
           },
         }),
       ]);
-      
       const client = new RedisClient(url);
       const deposits = await client.getDeposits('Ethereum', 'ETH', '0x1234');
       expect(deposits).toEqual([
         {
-          amount: 32768n,
+          amount: 0x8000n,
           asset: 'ETH',
           deposit_chain_block_height: 1234,
-          tx_refs: [ '0xdeadc0de' ]
-        }
+          tx_refs: ['0xdeadc0de'],
+        },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Ethereum:0x1234', 0, -1);
+    });
+
+    it('returns the deposits if found - Polkadot', async () => {
+      const mock = jest.mocked(Redis.prototype.lrange).mockResolvedValueOnce([
+        JSON.stringify({
+          amount: '0x8000',
+          asset: 'DOT',
+          deposit_chain_block_height: 100,
+          deposit_details: {
+            extrinsic_index: 20,
+          },
+        }),
+      ]);
+
+      const client = new RedisClient(url);
+      const deposits = await client.getDeposits(
+        'Polkadot',
+        'DOT',
+        '121LWHo3TJYdvSuDVhdCY6P9Bk6Cd5wMkkvMnU5joWJfuWBJ',
+      );
+      expect(deposits).toEqual([
+        {
+          amount: 0x8000n,
+          asset: 'DOT',
+          deposit_chain_block_height: 100,
+          tx_refs: ['100-20'],
+        },
+      ]);
+      expect(mock).toHaveBeenCalledWith(
+        'deposit:Polkadot:0x2c7de4a2d760264b29f2033b67aa882f300e1785bc7d130fbf67f5b127202169',
+        0,
+        -1,
+      );
     });
 
     it('>V120 returns the deposits if found', async () => {
@@ -131,7 +163,7 @@ describe(RedisClient, () => {
           deposit_details: {
             tx_id: '0x1234',
             vout: 1,
-          }
+          },
         }),
       ]);
       const client = new RedisClient(url);

--- a/packages/shared/src/node-apis/__tests__/redis.test.ts
+++ b/packages/shared/src/node-apis/__tests__/redis.test.ts
@@ -108,6 +108,7 @@ describe(RedisClient, () => {
           },
         }),
       ]);
+      
       const client = new RedisClient(url);
       const deposits = await client.getDeposits('Ethereum', 'ETH', '0x1234');
       expect(deposits).toEqual([
@@ -135,10 +136,10 @@ describe(RedisClient, () => {
             chain: 'Bitcoin',
           },
           deposit_chain_block_height: 1234,
-          deposit_details: {
-            tx_id: '0x1234',
-            vout: 1,
-          },
+          deposit_details: { 
+            tx_id: '0x1234', 
+            vout: 1
+          }
         }),
       ]);
       const client = new RedisClient(url);
@@ -148,10 +149,10 @@ describe(RedisClient, () => {
           amount: 0x8000n,
           asset: 'BTC',
           deposit_chain_block_height: 1234,
-          deposit_details: {
-            tx_id: '0x1234',
-            vout: 1,
-          },
+          deposit_details: { 
+            tx_id: '3412', 
+            vout: 1
+          }
         },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Bitcoin:0x1234', 0, -1);

--- a/packages/shared/src/node-apis/__tests__/redis.test.ts
+++ b/packages/shared/src/node-apis/__tests__/redis.test.ts
@@ -101,10 +101,7 @@ describe(RedisClient, () => {
           asset: 'ETH',
           deposit_chain_block_height: 1234,
           deposit_details: {
-            tx_hashes: [
-              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
-              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
-            ],
+            tx_hashes: ["0xdeadc0de"]
           },
         }),
       ]);
@@ -113,16 +110,11 @@ describe(RedisClient, () => {
       const deposits = await client.getDeposits('Ethereum', 'ETH', '0x1234');
       expect(deposits).toEqual([
         {
-          amount: 0x8000n,
+          amount: 32768n,
           asset: 'ETH',
           deposit_chain_block_height: 1234,
-          deposit_details: {
-            tx_hashes: [
-              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
-              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
-            ],
-          },
-        },
+          tx_refs: [ '0xdeadc0de' ]
+        }
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Ethereum:0x1234', 0, -1);
     });
@@ -136,9 +128,9 @@ describe(RedisClient, () => {
             chain: 'Bitcoin',
           },
           deposit_chain_block_height: 1234,
-          deposit_details: { 
-            tx_id: '0x1234', 
-            vout: 1
+          deposit_details: {
+            tx_id: '0x1234',
+            vout: 1,
           }
         }),
       ]);
@@ -149,10 +141,7 @@ describe(RedisClient, () => {
           amount: 0x8000n,
           asset: 'BTC',
           deposit_chain_block_height: 1234,
-          deposit_details: { 
-            tx_id: '3412', 
-            vout: 1
-          }
+          tx_refs: ['3412'],
         },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Bitcoin:0x1234', 0, -1);
@@ -164,12 +153,7 @@ describe(RedisClient, () => {
           amount: '0x8000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234,
-          deposit_details: {
-            tx_hashes: [
-              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
-              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
-            ],
-          },
+          tx_refs: ['0x65f4c6ba793815c4d1a9e4f0fd43c0f6f26ff5f1678a621d543a8928c1c2e978'],
         }),
       ]);
       const client = new RedisClient(url);

--- a/packages/shared/src/node-apis/__tests__/redis.test.ts
+++ b/packages/shared/src/node-apis/__tests__/redis.test.ts
@@ -100,6 +100,12 @@ describe(RedisClient, () => {
           amount: '0x8000',
           asset: 'ETH',
           deposit_chain_block_height: 1234,
+          deposit_details: {
+            tx_hashes: [
+              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
+              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
+            ],
+          },
         }),
       ]);
       const client = new RedisClient(url);
@@ -109,6 +115,12 @@ describe(RedisClient, () => {
           amount: 0x8000n,
           asset: 'ETH',
           deposit_chain_block_height: 1234,
+          deposit_details: {
+            tx_hashes: [
+              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
+              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
+            ],
+          },
         },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Ethereum:0x1234', 0, -1);
@@ -123,6 +135,10 @@ describe(RedisClient, () => {
             chain: 'Bitcoin',
           },
           deposit_chain_block_height: 1234,
+          deposit_details: { 
+            tx_id: '0x1234', 
+            vout: 1
+          }
         }),
       ]);
       const client = new RedisClient(url);
@@ -132,6 +148,10 @@ describe(RedisClient, () => {
           amount: 0x8000n,
           asset: 'BTC',
           deposit_chain_block_height: 1234,
+          deposit_details: { 
+            tx_id: '0x1234', 
+            vout: 1
+          }
         },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Bitcoin:0x1234', 0, -1);
@@ -143,6 +163,12 @@ describe(RedisClient, () => {
           amount: '0x8000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234,
+          deposit_details: {
+            tx_hashes: [
+              '0x6e1bb8a886326085d5fc9f8aa3e0e3fd0076e1035f43399052c3917f7380fbc9',
+              '0x4abb22dbe369911543c51c48ff7967e331b552a461db2b5c39fd46ddbd1e400d',
+            ],
+          },
         }),
       ]);
       const client = new RedisClient(url);

--- a/packages/shared/src/node-apis/__tests__/redis.test.ts
+++ b/packages/shared/src/node-apis/__tests__/redis.test.ts
@@ -135,10 +135,10 @@ describe(RedisClient, () => {
             chain: 'Bitcoin',
           },
           deposit_chain_block_height: 1234,
-          deposit_details: { 
-            tx_id: '0x1234', 
-            vout: 1
-          }
+          deposit_details: {
+            tx_id: '0x1234',
+            vout: 1,
+          },
         }),
       ]);
       const client = new RedisClient(url);
@@ -148,10 +148,10 @@ describe(RedisClient, () => {
           amount: 0x8000n,
           asset: 'BTC',
           deposit_chain_block_height: 1234,
-          deposit_details: { 
-            tx_id: '0x1234', 
-            vout: 1
-          }
+          deposit_details: {
+            tx_id: '0x1234',
+            vout: 1,
+          },
         },
       ]);
       expect(mock).toHaveBeenCalledWith('deposit:Bitcoin:0x1234', 0, -1);

--- a/packages/shared/src/node-apis/redis.ts
+++ b/packages/shared/src/node-apis/redis.ts
@@ -30,18 +30,12 @@ const ArbitrumDeposit = z.object({
   tx_hashes: z.array(hexString),
 });
 
-
 const depositSchema = jsonString.pipe(
   z.object({
     amount: u128,
     asset: z.union([string, chainAsset]),
     deposit_chain_block_height: number,
-    deposit_details: z.union([
-      BitcoinDeposit,
-      EthereumDeposit,
-      PolkadotDeposit,
-      ArbitrumDeposit,
-    ])
+    deposit_details: z.union([BitcoinDeposit, EthereumDeposit, PolkadotDeposit, ArbitrumDeposit]),
   }),
 );
 

--- a/packages/shared/src/node-apis/redis.ts
+++ b/packages/shared/src/node-apis/redis.ts
@@ -12,8 +12,6 @@ const jsonString = string.transform((value) => JSON.parse(value));
 
 const chainAsset = uncheckedAssetAndChain.transform(({ asset }) => asset);
 
-const PolkadotExtrinsicIndex = z.number();
-
 const BitcoinDeposit = z.object({
   tx_id: hexString,
   vout: z.number().int(),
@@ -23,7 +21,7 @@ const EthereumDeposit = z.object({
   tx_hashes: z.array(hexString),
 });
 const PolkadotDeposit = z.object({
-  extrinsic_index: PolkadotExtrinsicIndex,
+  extrinsic_index: z.number(),
 });
 
 const ArbitrumDeposit = z.object({

--- a/packages/shared/src/node-apis/redis.ts
+++ b/packages/shared/src/node-apis/redis.ts
@@ -5,7 +5,7 @@ import { sorter } from '../arrays';
 import { formatTxHash } from '../common';
 import { type Asset, type Chain } from '../enums';
 import { number, u128, string, uncheckedAssetAndChain, hexString } from '../parsers';
- 
+
 const ss58ToHex = (address: string) =>
   `0x${Buffer.from(ss58.decode(address).data).toString('hex')}`;
 
@@ -14,7 +14,7 @@ const jsonString = string.transform((value) => JSON.parse(value));
 const chainAsset = uncheckedAssetAndChain.transform(({ asset }) => asset);
 
 const BitcoinDeposit = z.object({
-  tx_id: hexString.transform((value) => formatTxHash("Bitcoin", value)),
+  tx_id: hexString.transform((value) => formatTxHash('Bitcoin', value)),
   vout: z.number().int(),
 });
 
@@ -27,7 +27,7 @@ const EVMDeposit = z.object({
 type EVMDepositType = z.infer<typeof EVMDeposit>;
 
 const PolkadotDeposit = z.object({
-  extrinsic_index: z.string(),
+  extrinsic_index: z.number(),
 });
 
 type PolkadotDepositType = z.infer<typeof PolkadotDeposit>;
@@ -41,7 +41,9 @@ const depositSchema = jsonString.pipe(
   }),
 );
 
-type PendingDeposit = Omit<z.output<typeof depositSchema>, 'deposit_details'> & { tx_refs: string[] };
+type PendingDeposit = Omit<z.output<typeof depositSchema>, 'deposit_details'> & {
+  tx_refs: string[];
+};
 
 type Deposit = z.infer<typeof depositSchema>;
 
@@ -149,43 +151,41 @@ export default class RedisClient {
     const value = await this.client.get(key);
     return value ? broadcastParsers[chain].parse(JSON.parse(value)) : null;
   }
-  
+
   async getDeposits(chain: Chain, asset: Asset, address: string): Promise<PendingDeposit[]> {
     const parsedAddress = chain === 'Polkadot' ? ss58ToHex(address) : address;
     const key = `deposit:${chain}:${parsedAddress}`;
     const deposits = await this.client.lrange(key, 0, -1);
-  
     return deposits
       .map((deposit) => {
-        const parsedDeposit = depositSchema.parse(deposit);  
-        const { deposit_details, deposit_chain_block_height } = parsedDeposit;  
-  
+        const parsedDeposit = depositSchema.parse(deposit);
         const baseDeposit = {
           amount: parsedDeposit.amount,
           asset: parsedDeposit.asset,
           deposit_chain_block_height: parsedDeposit.deposit_chain_block_height,
         };
-  
+        const { deposit_details, deposit_chain_block_height } = parsedDeposit;
+
         if (!deposit_details) return { ...baseDeposit, tx_refs: [] };
-  
+
         switch (chain) {
           case 'Ethereum':
           case 'Arbitrum':
             return { ...baseDeposit, tx_refs: (deposit_details as EVMDepositType).tx_hashes };
           case 'Bitcoin':
-            return { ...baseDeposit, tx_refs: [(deposit_details as BitcoinDepositType).tx_id]  };
+            return { ...baseDeposit, tx_refs: [(deposit_details as BitcoinDepositType).tx_id] };
           case 'Polkadot': {
             const extrinsicIndex = `${deposit_chain_block_height}-${(deposit_details as PolkadotDepositType).extrinsic_index || ''}`;
             return { ...baseDeposit, tx_refs: [extrinsicIndex] };
           }
           default:
-            return { ...baseDeposit, tx_refs: [] };  
+            return { ...baseDeposit, tx_refs: [] };
         }
       })
-      .filter((deposit) => deposit.asset === asset) 
-      .sort(sortDepositAscending);  
+      .filter((deposit) => deposit.asset === asset)
+      .sort(sortDepositAscending);
   }
-  
+
   async getMempoolTransaction(chain: 'Bitcoin', address: string) {
     const key = `mempool:${chain}:${address}`;
     const value = await this.client.get(key);

--- a/packages/shared/src/node-apis/redis.ts
+++ b/packages/shared/src/node-apis/redis.ts
@@ -12,11 +12,36 @@ const jsonString = string.transform((value) => JSON.parse(value));
 
 const chainAsset = uncheckedAssetAndChain.transform(({ asset }) => asset);
 
+const PolkadotExtrinsicIndex = z.number();
+
+const BitcoinDeposit = z.object({
+  tx_id: hexString,
+  vout: z.number().int(),
+});
+
+const EthereumDeposit = z.object({
+  tx_hashes: z.array(hexString),
+});
+const PolkadotDeposit = z.object({
+  extrinsic_index: PolkadotExtrinsicIndex,
+});
+
+const ArbitrumDeposit = z.object({
+  tx_hashes: z.array(hexString),
+});
+
+
 const depositSchema = jsonString.pipe(
   z.object({
     amount: u128,
     asset: z.union([string, chainAsset]),
     deposit_chain_block_height: number,
+    deposit_details: z.union([
+      BitcoinDeposit,
+      EthereumDeposit,
+      PolkadotDeposit,
+      ArbitrumDeposit,
+    ])
   }),
 );
 

--- a/packages/shared/src/node-apis/redis.ts
+++ b/packages/shared/src/node-apis/redis.ts
@@ -13,31 +13,31 @@ const jsonString = string.transform((value) => JSON.parse(value));
 
 const chainAsset = uncheckedAssetAndChain.transform(({ asset }) => asset);
 
-const BitcoinDeposit = z.object({
+const bitcoinDeposit = z.object({
   tx_id: hexString.transform((value) => formatTxHash('Bitcoin', value)),
   vout: z.number().int(),
 });
 
-type BitcoinDepositType = z.infer<typeof BitcoinDeposit>;
+type BitcoinDepositType = z.infer<typeof bitcoinDeposit>;
 
-const EVMDeposit = z.object({
+const evmDeposit = z.object({
   tx_hashes: z.array(hexString),
 });
 
-type EVMDepositType = z.infer<typeof EVMDeposit>;
+type EvmDepositType = z.infer<typeof evmDeposit>;
 
-const PolkadotDeposit = z.object({
+const polkadotDeposit = z.object({
   extrinsic_index: z.number(),
 });
 
-type PolkadotDepositType = z.infer<typeof PolkadotDeposit>;
+type PolkadotDepositType = z.infer<typeof polkadotDeposit>;
 
 const depositSchema = jsonString.pipe(
   z.object({
     amount: u128,
     asset: z.union([string, chainAsset]),
     deposit_chain_block_height: number,
-    deposit_details: z.union([EVMDeposit, BitcoinDeposit, PolkadotDeposit]).optional(),
+    deposit_details: z.union([evmDeposit, bitcoinDeposit, polkadotDeposit]).optional(),
   }),
 );
 
@@ -171,7 +171,7 @@ export default class RedisClient {
         switch (chain) {
           case 'Ethereum':
           case 'Arbitrum':
-            return { ...baseDeposit, tx_refs: (deposit_details as EVMDepositType).tx_hashes };
+            return { ...baseDeposit, tx_refs: (deposit_details as EvmDepositType).tx_hashes };
           case 'Bitcoin':
             return { ...baseDeposit, tx_refs: [(deposit_details as BitcoinDepositType).tx_id] };
           case 'Polkadot': {

--- a/packages/swap/src/event-handlers/__tests__/networkTransactionRejectedByBroker.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/networkTransactionRejectedByBroker.test.ts
@@ -1,5 +1,5 @@
+import { formatTxHash } from '@/shared/common'
 import prisma from '../../client';
-import { formatTxHash } from '../common';
 import networkTransactionRejectedByBroker from '../networkTransactionRejectedByBroker';
 
 describe(networkTransactionRejectedByBroker, () => {

--- a/packages/swap/src/event-handlers/__tests__/networkTransactionRejectedByBroker.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/networkTransactionRejectedByBroker.test.ts
@@ -1,4 +1,4 @@
-import { formatTxHash } from '@/shared/common'
+import { formatTxHash } from '@/shared/common';
 import prisma from '../../client';
 import networkTransactionRejectedByBroker from '../networkTransactionRejectedByBroker';
 

--- a/packages/swap/src/event-handlers/common.ts
+++ b/packages/swap/src/event-handlers/common.ts
@@ -2,13 +2,11 @@ import { bitcoinIngressEgressDepositFinalised as bitcoinSchema160 } from '@chain
 import { ethereumIngressEgressDepositFinalised } from '@chainflip/processor/160/ethereumIngressEgress/depositFinalised';
 import { polkadotIngressEgressDepositFinalised } from '@chainflip/processor/160/polkadotIngressEgress/depositFinalised';
 import { bitcoinIngressEgressDepositFinalised as bitcoinSchema170 } from '@chainflip/processor/170/bitcoinIngressEgress/depositFinalised';
-import * as base58 from '@chainflip/utils/base58';
-import { hexToBytes, reverseBytes } from '@chainflip/utils/bytes';
-import type { HexString } from '@chainflip/utils/types';
 // @ts-expect-error should still work
 import { Metadata, TypeRegistry } from '@polkadot/types';
 import assert from 'assert';
 import { z } from 'zod';
+import { formatTxHash } from "@/shared/common"; 
 import { Chain } from '@/shared/enums';
 import { assertUnreachable } from '@/shared/functions';
 import {
@@ -124,21 +122,6 @@ export const getStateChainError = async (
     },
   });
 };
-
-export function formatTxHash(chain: Chain, txHash: string): string;
-export function formatTxHash(chain: Chain, txHash: string | undefined): string | undefined;
-export function formatTxHash(chain: Chain, txHash: string | undefined) {
-  if (!txHash) return txHash;
-
-  switch (chain) {
-    case 'Bitcoin':
-      return reverseBytes(txHash.slice(2));
-    case 'Solana':
-      return base58.encode(hexToBytes(txHash as HexString));
-    default:
-      return txHash;
-  }
-}
 
 export const getDepositTxRef = (
   chain: Chain,

--- a/packages/swap/src/event-handlers/common.ts
+++ b/packages/swap/src/event-handlers/common.ts
@@ -6,7 +6,7 @@ import { bitcoinIngressEgressDepositFinalised as bitcoinSchema170 } from '@chain
 import { Metadata, TypeRegistry } from '@polkadot/types';
 import assert from 'assert';
 import { z } from 'zod';
-import { formatTxHash } from "@/shared/common"; 
+import { formatTxHash } from '@/shared/common';
 import { Chain } from '@/shared/enums';
 import { assertUnreachable } from '@/shared/functions';
 import {

--- a/packages/swap/src/event-handlers/swapRequested.ts
+++ b/packages/swap/src/event-handlers/swapRequested.ts
@@ -1,10 +1,10 @@
 import { swappingSwapRequested as schema160 } from '@chainflip/processor/160/swapping/swapRequested';
 import { swappingSwapRequested as schema170 } from '@chainflip/processor/170/swapping/swapRequested';
 import z from 'zod';
+import { formatTxHash } from '@/shared/common';
 import { assetConstants, InternalAsset } from '@/shared/enums';
 import { assertNever } from '@/shared/guards';
 import { pascalCaseToScreamingSnakeCase } from '@/shared/strings';
-import { formatTxHash } from './common';
 import { Prisma } from '../client';
 import type { EventHandlerArgs } from './index';
 

--- a/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
+++ b/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
@@ -51,9 +51,9 @@ describe('ingress-egress-tracking', () => {
           amount: '0x9000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234567890,
-          deposit_details: { 
-            tx_hashes: ["0x1234"]
-          }
+          deposit_details: {
+            tx_hashes: ['0x1234'],
+          },
         }),
       );
 
@@ -71,9 +71,9 @@ describe('ingress-egress-tracking', () => {
           amount: '0x9000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234567890,
-          deposit_details: { 
-            tx_hashes: ["0x1234"]
-          }
+          deposit_details: {
+            tx_hashes: ['0x1234'],
+          },
         }),
       );
 
@@ -102,7 +102,6 @@ describe('ingress-egress-tracking', () => {
       );
 
       const deposit = await getPendingDeposit('Btc', 'tb1q8uzv43phxxsndlxglj74ryc6umxuzuz22u7erf');
-
       expect(logger.error).not.toHaveBeenCalled();
       expect(deposit).toEqual({
         amount: '36864',
@@ -127,7 +126,7 @@ describe('ingress-egress-tracking', () => {
             amount: '0x9000',
             asset: 'BTC',
             deposit_chain_block_height: 1234567890,
-            deposit_details: { tx_id: '0x1234', vout: 1, }
+            deposit_details: { tx_id: '0x1234', vout: 1 },
           }),
         ),
         updateChainTracking({ chain: 'Bitcoin', height: 1234567894n }),

--- a/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
+++ b/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
@@ -102,6 +102,7 @@ describe('ingress-egress-tracking', () => {
       );
 
       const deposit = await getPendingDeposit('Btc', 'tb1q8uzv43phxxsndlxglj74ryc6umxuzuz22u7erf');
+
       expect(logger.error).not.toHaveBeenCalled();
       expect(deposit).toEqual({
         amount: '36864',
@@ -133,6 +134,7 @@ describe('ingress-egress-tracking', () => {
       ]);
 
       const deposit = await getPendingDeposit('Btc', 'tb1q8uzv43phxxsndlxglj74ryc6umxuzuz22u7erf');
+
       expect(logger.error).not.toHaveBeenCalled();
       expect(deposit).toEqual({ amount: '36864', transactionConfirmations: 4 });
     });

--- a/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
+++ b/packages/swap/src/ingress-egress-tracking/__tests__/index.test.ts
@@ -51,6 +51,9 @@ describe('ingress-egress-tracking', () => {
           amount: '0x9000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234567890,
+          deposit_details: { 
+            tx_hashes: ["0x1234"]
+          }
         }),
       );
 
@@ -68,6 +71,9 @@ describe('ingress-egress-tracking', () => {
           amount: '0x9000',
           asset: 'FLIP',
           deposit_chain_block_height: 1234567890,
+          deposit_details: { 
+            tx_hashes: ["0x1234"]
+          }
         }),
       );
 
@@ -121,13 +127,13 @@ describe('ingress-egress-tracking', () => {
             amount: '0x9000',
             asset: 'BTC',
             deposit_chain_block_height: 1234567890,
+            deposit_details: { tx_id: '0x1234', vout: 1, }
           }),
         ),
         updateChainTracking({ chain: 'Bitcoin', height: 1234567894n }),
       ]);
 
       const deposit = await getPendingDeposit('Btc', 'tb1q8uzv43phxxsndlxglj74ryc6umxuzuz22u7erf');
-
       expect(logger.error).not.toHaveBeenCalled();
       expect(deposit).toEqual({ amount: '36864', transactionConfirmations: 4 });
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7478,10 +7478,10 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@polkadot/networks': 13.0.2
       '@polkadot/util': 13.0.2
-      '@polkadot/wasm-crypto': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))
+      '@polkadot/wasm-crypto': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
       '@polkadot/x-bigint': 13.0.2
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2))
+      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       '@scure/base': 1.1.6
       tslib: 2.8.1
 
@@ -7512,11 +7512,11 @@ snapshots:
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
-  '@polkadot/wasm-bridge@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))':
+  '@polkadot/wasm-bridge@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 13.0.2
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2))
+      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
   '@polkadot/wasm-crypto-asmjs@7.3.2(@polkadot/util@12.6.2)':
@@ -7539,14 +7539,14 @@ snapshots:
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-init@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))':
+  '@polkadot/wasm-crypto-init@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 13.0.2
-      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))
+      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
       '@polkadot/wasm-crypto-asmjs': 7.3.2(@polkadot/util@13.0.2)
       '@polkadot/wasm-crypto-wasm': 7.3.2(@polkadot/util@13.0.2)
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2))
+      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
   '@polkadot/wasm-crypto-wasm@7.3.2(@polkadot/util@12.6.2)':
@@ -7572,15 +7572,15 @@ snapshots:
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))':
+  '@polkadot/wasm-crypto@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 13.0.2
-      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))
+      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
       '@polkadot/wasm-crypto-asmjs': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-crypto-init': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)))
+      '@polkadot/wasm-crypto-init': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
       '@polkadot/wasm-crypto-wasm': 7.3.2(@polkadot/util@13.0.2)
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2))
+      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.8.1
 
   '@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)':
@@ -7624,10 +7624,10 @@ snapshots:
       '@polkadot/x-global': 12.6.2
       tslib: 2.8.1
 
-  '@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2))':
+  '@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))':
     dependencies:
       '@polkadot/util': 13.0.2
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
+      '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/x-global': 13.0.2
       tslib: 2.8.1
 


### PR DESCRIPTION
Added `deposit_details` field on `depositSchema` from the [backend]( https://github.com/chainflip-io/chainflip-backend/pull/5320)

```
enum DepositDetails {
	Bitcoin { tx_id: H256, vout: u32 },
	Ethereum { tx_hashes: Vec<H256> },
	Polkadot { extrinsic_index: PolkadotExtrinsicIndex },
	Arbitrum { tx_hashes: Vec<H256> },
}
```