### PR TITLE
fix(swap): check number of chunks [WEB-1971]

### DIFF
--- a/packages/swap/src/routes/__tests__/v2/quote.test.ts
+++ b/packages/swap/src/routes/__tests__/v2/quote.test.ts
@@ -20,7 +20,7 @@ import Quoter from '../../../quoting/Quoter';
 import app from '../../../server';
 import { boostPoolsCache } from '../../../utils/boost';
 import { getTotalLiquidity } from '../../../utils/pools';
-import { getDcaQuoteParams } from '../../v2/quote';
+import { getDcaQuoteParams, MAX_NUMBER_OF_CHUNKS } from '../../v2/quote';
 
 vi.mock('../../../utils/function', async (importOriginal) => {
   const original = (await importOriginal()) as object;
@@ -118,6 +118,15 @@ describe(getDcaQuoteParams, () => {
     vi.mocked(getUsdValue).mockResolvedValue('30');
 
     const result = await getDcaQuoteParams('Btc', 90n);
+    expect(result).toEqual(null);
+  });
+
+  it('should correctly handle number of chunks bigger than max', async () => {
+    const chunkSizeUsd = BigInt(env.DCA_CHUNK_SIZE_USD?.Btc ?? env.DCA_DEFAULT_CHUNK_SIZE_USD);
+    const maxUsdValue = MAX_NUMBER_OF_CHUNKS * chunkSizeUsd + 1n;
+    vi.mocked(getUsdValue).mockResolvedValue(maxUsdValue.toString());
+
+    const result = await getDcaQuoteParams('Btc', 1n);
     expect(result).toEqual(null);
   });
 });

--- a/packages/swap/src/routes/v2/quote.ts
+++ b/packages/swap/src/routes/v2/quote.ts
@@ -18,6 +18,8 @@ import ServiceError from '../../utils/ServiceError';
 import { asyncHandler, handleQuotingError } from '../common';
 import { fallbackChains } from '../quote';
 
+export const MAX_NUMBER_OF_CHUNKS = 2n ** 32n - 1n;
+
 const router = express.Router();
 
 export const getDcaQuoteParams = async (asset: InternalAsset, amount: bigint) => {
@@ -34,6 +36,11 @@ export const getDcaQuoteParams = async (asset: InternalAsset, amount: bigint) =>
     return null;
   }
   const numberOfChunks = Math.ceil(Number(usdValue) / usdChunkSize);
+
+  if (numberOfChunks > MAX_NUMBER_OF_CHUNKS) {
+    logger.error(`number of chunks does not fit u32 type`);
+    return null;
+  }
 
   return {
     chunkSize: BigInt(new BigNumber(amount.toString()).dividedBy(numberOfChunks).toFixed(0)),


### PR DESCRIPTION
Fix quoting when DCA is enabled.

We should check `numberOfChunks` to be less than 2**32, which is the maximum number of chunks the node can accept, since we have `u32` type for the `number_of_chunks` in our rpc method.
