### PR TITLE
refactor(swap): inspect errors

### DIFF
--- a/packages/swap/src/ingress-egress-tracking/index.ts
+++ b/packages/swap/src/ingress-egress-tracking/index.ts
@@ -1,6 +1,7 @@
 import { findVaultSwapData as findBitcoinVaultSwapData } from '@chainflip/bitcoin';
 import { findVaultSwapData as findSolanaVaultSwapData } from '@chainflip/solana';
 import { isTruthy } from '@chainflip/utils/guard';
+import { inspect } from 'util';
 import { Chain, Chains, InternalAsset, assetConstants } from '@/shared/enums';
 import RedisClient from '@/shared/node-apis/redis';
 import { getTransactionRefChains } from '@/swap/utils/transactionRef';
@@ -88,7 +89,7 @@ export const getPendingDeposit = async (
       txRef: deposits[0].tx_refs?.[0],
     };
   } catch (error) {
-    logger.error('error while looking up deposit in redis', { error });
+    logger.error('error while looking up deposit in redis', { error: inspect(error) });
     return null;
   }
 };
@@ -98,7 +99,7 @@ export const getPendingBroadcast = async (broadcast: Broadcast) => {
   try {
     return await redis.getBroadcast(broadcast.chain, broadcast.nativeId);
   } catch (error) {
-    logger.error('error while looking up broadcast in redis', { error });
+    logger.error('error while looking up broadcast in redis', { error: inspect(error) });
     return null;
   }
 };
@@ -155,7 +156,7 @@ export const getPendingVaultSwap = async (txRef: string) => {
       ...remainingData,
     };
   } catch (error) {
-    logger.error('error while looking up vault swap in redis', { error });
+    logger.error('error while looking up vault swap in redis', { error: inspect(error) });
     return null;
   }
 };

--- a/packages/swap/src/processBlocks.ts
+++ b/packages/swap/src/processBlocks.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { GraphQLClient } from 'graphql-request';
 import { performance } from 'perf_hooks';
 import { setTimeout as sleep } from 'timers/promises';
+import { inspect } from 'util';
 import prisma from './client';
 import env from './config/env';
 import { getEventHandler, swapEventNames } from './event-handlers';
@@ -40,7 +41,7 @@ const fetchBlocks = async (height: number): Promise<Block[]> => {
 
       return blocks;
     } catch (error) {
-      logger.error('failed to fetch batch', { error });
+      logger.error('failed to fetch batch', { error: inspect(error) });
       if (i === 4) throw error;
     }
   }

--- a/packages/swap/src/processor.ts
+++ b/packages/swap/src/processor.ts
@@ -1,10 +1,11 @@
+import { inspect } from 'util';
 import processBlocks from './processBlocks';
 import logger from './utils/logger';
 
 // start
 const start = () => {
   processBlocks().catch((error) => {
-    logger.error('error processing blocks', { error });
+    logger.error('error processing blocks', { error: inspect(error) });
     process.exit(1);
   });
 };

--- a/packages/swap/src/routes/common.ts
+++ b/packages/swap/src/routes/common.ts
@@ -1,6 +1,7 @@
 import { RequestHandler, ErrorRequestHandler } from 'express';
 import * as express from 'express';
 import type { RouteParameters } from 'express-serve-static-core';
+import { inspect } from 'util';
 import { InternalAsset } from '@/shared/enums';
 import env from '../config/env';
 import type Quoter from '../quoting/Quoter';
@@ -8,12 +9,16 @@ import logger from '../utils/logger';
 import ServiceError from '../utils/ServiceError';
 
 export const handleError: ErrorRequestHandler = (error, req, res, _next) => {
-  logger.customInfo('received error', {}, { error });
+  logger.customInfo('received error', {}, { error: inspect(error) });
 
   if (error instanceof ServiceError) {
     res.status(error.code).json(error.toJSON());
   } else {
-    logger.customError('unknown error occurred', { alertCode: 'UnknownError' }, { error });
+    logger.customError(
+      'unknown error occurred',
+      { alertCode: 'UnknownError' },
+      { error: inspect(error) },
+    );
     res.status(500).json({ message: 'unknown error' });
   }
 };

--- a/packages/swap/src/utils/isDisallowedSwap.ts
+++ b/packages/swap/src/utils/isDisallowedSwap.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance, isAxiosError } from 'axios';
 import { AML } from 'elliptic-sdk';
+import { inspect } from 'util';
 import { z } from 'zod';
 import logger from './logger';
 import prisma from '../client';
@@ -32,7 +33,7 @@ const isTooRisky = async (address: string | undefined): Promise<boolean> => {
     return parsed.risk_score !== null && parsed.risk_score >= env.ELLIPTIC_RISK_SCORE_TOLERANCE;
   } catch (error) {
     const level = isAxiosError(error) && error.status === 404 ? 'warn' : 'error';
-    logger[level]('failed to request risk score from elliptic', { error });
+    logger[level]('failed to request risk score from elliptic', { error: inspect(error) });
     return false;
   }
 };


### PR DESCRIPTION
the log will have `{ error: {} }`, instead of any useful information. if you use `inspect`, it will actually print the error