### PR TITLE
chore(swap): add indexes to swap, swapFee and swapRequest tables

### DIFF
--- a/packages/swap/prisma/migrations/20250526085439_add_indexes_to_swap_swaprequest_swapfee/migration.sql
+++ b/packages/swap/prisma/migrations/20250526085439_add_indexes_to_swap_swaprequest_swapfee/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "Swap_nativeId_idx" ON "public"."Swap"("nativeId");
+
+-- CreateIndex
+CREATE INDEX "SwapFee_swapRequestId_idx" ON "public"."SwapFee"("swapRequestId");
+
+-- CreateIndex
+CREATE INDEX "SwapRequest_nativeId_idx" ON "public"."SwapRequest"("nativeId");

--- a/packages/swap/prisma/schema.prisma
+++ b/packages/swap/prisma/schema.prisma
@@ -201,6 +201,7 @@ model SwapRequest {
   onChainSwapInfo            OnChainSwapInfo?
 
   @@index([srcAsset, prewitnessedDepositId])
+  @@index([nativeId])
   @@schema("public")
 }
 
@@ -237,6 +238,7 @@ model Swap {
   swapRequest                     SwapRequest   @relation(fields: [swapRequestId], references: [id])
   swapRequestId                   BigInt
 
+  @@index([nativeId])
   @@schema("public")
 }
 
@@ -263,6 +265,7 @@ model SwapFee {
   amount        Decimal       @db.Decimal(30, 0)
 
   @@index([swapId])
+  @@index([swapRequestId])
   @@schema("public")
 }
 


### PR DESCRIPTION
index hit rate was pretty low on these 3 tables and nativeId and swapRequestId are the fields that are used in where conditions
![image](https://github.com/user-attachments/assets/648cd70c-75d1-4822-881b-a2a980b80b90)
