### PR TITLE
refactor(swap): use min recommended live price slippage

### DIFF
--- a/packages/swap/src/quoting/QuoteRequest.ts
+++ b/packages/swap/src/quoting/QuoteRequest.ts
@@ -362,7 +362,7 @@ export default class QuoteRequest {
         destAsset: this.destAsset,
       });
 
-    const minRecommendedLivePriceSlippageTolerancePercent = isNotNullish(
+    const cappedRecommendedLivePriceSlippageTolerancePercent = isNotNullish(
       recommendedLivePriceSlippageTolerancePercent,
     )
       ? Math.min(recommendedLivePriceSlippageTolerancePercent, recommendedSlippageTolerancePercent)
@@ -372,7 +372,8 @@ export default class QuoteRequest {
       intermediateAmount: intermediateAmount?.toString(),
       egressAmount: egressAmount.toString(),
       recommendedSlippageTolerancePercent,
-      recommendedLivePriceSlippageTolerancePercent: minRecommendedLivePriceSlippageTolerancePercent,
+      recommendedLivePriceSlippageTolerancePercent:
+        cappedRecommendedLivePriceSlippageTolerancePercent,
       includedFees: includedFees.map((fee) => ({ ...fee, amount: fee.amount.toString() })),
       lowLiquidityWarning,
       poolInfo,

--- a/packages/swap/src/quoting/QuoteRequest.ts
+++ b/packages/swap/src/quoting/QuoteRequest.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import { Query } from 'express-serve-static-core';
 import { CHAINFLIP_STATECHAIN_BLOCK_TIME_SECONDS } from '@/shared/consts.js';
 import { getPipAmountFromAmount, ONE_IN_PIP } from '@/shared/functions.js';
-import { ensure } from '@/shared/guards.js';
+import { ensure, isNotNullish } from '@/shared/guards.js';
 import { getFulfilledResult } from '@/shared/promises.js';
 import {
   quoteQuerySchema,
@@ -345,23 +345,34 @@ export default class QuoteRequest {
       String(swapOutputAmount),
     );
 
+    const recommendedSlippageTolerancePercent = await calculateRecommendedSlippage({
+      srcAsset: this.srcAsset,
+      destAsset: this.destAsset,
+      boostFeeBps,
+      intermediateAmount,
+      egressAmount,
+      dcaChunks,
+      estimatedPrice,
+      isOnChain: this.isOnChain,
+    });
+
+    const recommendedLivePriceSlippageTolerancePercent =
+      await calculateRecommendedLivePriceSlippage({
+        srcAsset: this.srcAsset,
+        destAsset: this.destAsset,
+      });
+
+    const minRecommendedLivePriceSlippageTolerancePercent = isNotNullish(
+      recommendedLivePriceSlippageTolerancePercent,
+    )
+      ? Math.min(recommendedLivePriceSlippageTolerancePercent, recommendedSlippageTolerancePercent)
+      : undefined;
+
     return {
       intermediateAmount: intermediateAmount?.toString(),
       egressAmount: egressAmount.toString(),
-      recommendedSlippageTolerancePercent: await calculateRecommendedSlippage({
-        srcAsset: this.srcAsset,
-        destAsset: this.destAsset,
-        boostFeeBps,
-        intermediateAmount,
-        egressAmount,
-        dcaChunks,
-        estimatedPrice,
-        isOnChain: this.isOnChain,
-      }),
-      recommendedLivePriceSlippageTolerancePercent: await calculateRecommendedLivePriceSlippage({
-        srcAsset: this.srcAsset,
-        destAsset: this.destAsset,
-      }),
+      recommendedSlippageTolerancePercent,
+      recommendedLivePriceSlippageTolerancePercent: minRecommendedLivePriceSlippageTolerancePercent,
       includedFees: includedFees.map((fee) => ({ ...fee, amount: fee.amount.toString() })),
       lowLiquidityWarning,
       poolInfo,


### PR DESCRIPTION
Use min between recommended live price slippage tolerance and max. slippage tolerance percentages for the recommended live price slippage percent.

Live price slippage tolerance should be lower than max. slippage tolerance. If calculated recommended live price slippage tolerance percent exceeds recommended max. slippage tolerance percent, the recommended live price slippage tolerance percent must be capped at the max. slippage tolerance percent:

```
minRecommendedLivePriceSlippageTolerancePercent = min(recommendedLivePriceSlippageTolerancePercent, recommendedSlippageTolerancePercent)
```