### PR TITLE
feat: include supply pools in quoter boost calculations [WEB-3436]

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@chainflip/bitcoin": "2.1.1",
-    "@chainflip/rpc": "2.2.0-alpha.8",
+    "@chainflip/rpc": "2.2.0-alpha.9",
     "@chainflip/solana": "2.2.3",
-    "@chainflip/utils": "2.2.0-alpha.3",
+    "@chainflip/utils": "2.2.0-alpha.4",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",
     "bignumber.js": "^9.3.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -69,7 +69,7 @@
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/rpc": "2.2.0-alpha.9",
     "@chainflip/solana": "2.2.3",
-    "@chainflip/utils": "2.2.0-alpha.4",
+    "@chainflip/utils": "2.2.0-alpha.5",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",
     "bignumber.js": "^9.3.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -69,7 +69,7 @@
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/rpc": "2.2.0-alpha.9",
     "@chainflip/solana": "2.2.3",
-    "@chainflip/utils": "2.2.0-alpha.5",
+    "@chainflip/utils": "2.2.0-alpha.6",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",
     "bignumber.js": "^9.3.0",

--- a/packages/sdk/src/swap/sdk.ts
+++ b/packages/sdk/src/swap/sdk.ts
@@ -11,6 +11,7 @@ import {
   internalAssetToRpcAsset,
   ChainMap,
 } from '@chainflip/utils/chainflip';
+import { calculateTotalEffectiveBorrowableAmount } from '@chainflip/utils/lending';
 import { HexString } from '@chainflip/utils/types';
 import { initClient } from '@ts-rest/core';
 import { createApiContract } from '@/shared/api/contract.js';
@@ -30,8 +31,8 @@ import {
   RpcConfig,
   SupplyPoolsDepth,
   getAllBoostPoolsDepth,
+  getAllSupplyPoolsDepth,
   getEnvironment,
-  getSupplyPoolsDepth,
 } from '@/shared/rpc/index.js';
 import { validateSwapAmount } from '@/shared/rpc/utils.js';
 import { BoostQuote, Quote } from '@/shared/schemas.js';
@@ -180,7 +181,7 @@ export class SwapSDK {
   }
 
   private async getBtcSupplyPoolDepth(): Promise<SupplyPoolsDepth> {
-    return getSupplyPoolsDepth(this.rpcConfig, internalAssetToRpcAsset.Btc);
+    return getAllSupplyPoolsDepth(this.rpcConfig, internalAssetToRpcAsset.Btc);
   }
 
   private async getBoostPoolsDepth(): Promise<BoostPoolsDepth> {
@@ -321,7 +322,12 @@ export class SwapSDK {
         ...internalAssetToRpcAsset[depth.asset],
       })),
       ...btcSupplyPoolDepth.map((pool) => ({
-        availableAmount: pool.availableAmount,
+        // TODO(2.2): Document and simplify this logic by calculating the effective available amount in the RPC itself
+        availableAmount: calculateTotalEffectiveBorrowableAmount({
+          totalAmount: pool.totalAmount,
+          totalAvailableAmount: pool.availableAmount,
+          utilisationCap: pool.utilisationCap,
+        }),
         feeTierBps: 5, // supply pools boosts cost 5bps fixed
         poolType: 'SUPPLY' as const,
         ...pool.asset,

--- a/packages/sdk/src/swap/sdk.ts
+++ b/packages/sdk/src/swap/sdk.ts
@@ -22,6 +22,7 @@ import {
   requestSwapDepositAddress,
   requestSwapParameterEncoding,
 } from '@/shared/broker.js';
+import { SUPPLY_POOL_BOOST_FEE_BPS } from '@/shared/consts.js';
 import { MultiCache } from '@/shared/dataStructures.js';
 import { parseFoKParams } from '@/shared/functions.js';
 import { assert } from '@/shared/guards.js';
@@ -328,7 +329,7 @@ export class SwapSDK {
           totalAvailableAmount: pool.availableAmount,
           utilisationCap: pool.utilisationCap,
         }),
-        feeTierBps: 5, // supply pools boosts cost 5bps fixed
+        feeTierBps: SUPPLY_POOL_BOOST_FEE_BPS, // supply pools boosts cost 5bps fixed
         poolType: 'SUPPLY' as const,
         ...pool.asset,
       })),

--- a/packages/sdk/src/swap/sdk.ts
+++ b/packages/sdk/src/swap/sdk.ts
@@ -11,7 +11,7 @@ import {
   internalAssetToRpcAsset,
   ChainMap,
 } from '@chainflip/utils/chainflip';
-import { calculateTotalEffectiveBorrowableAmount } from '@chainflip/utils/lending';
+import { calculateTotalEffectiveBorrowableAmount, ppmToBps } from '@chainflip/utils/lending';
 import { HexString } from '@chainflip/utils/types';
 import { initClient } from '@ts-rest/core';
 import { createApiContract } from '@/shared/api/contract.js';
@@ -327,7 +327,7 @@ export class SwapSDK {
         availableAmount: calculateTotalEffectiveBorrowableAmount({
           totalAmount: pool.totalAmount,
           totalAvailableAmount: pool.availableAmount,
-          utilisationCap: pool.utilisationCap,
+          utilisationCapBps: ppmToBps(pool.utilisationCap ?? 1_000_000),
         }),
         feeTierBps: SUPPLY_POOL_BOOST_FEE_BPS, // supply pools boosts cost 5bps fixed
         poolType: 'SUPPLY' as const,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/rpc": "2.2.0-alpha.9",
-    "@chainflip/utils": "2.2.0-alpha.5",
+    "@chainflip/utils": "2.2.0-alpha.6",
     "@chainflip/solana": "2.2.3",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/rpc": "2.2.0-alpha.9",
-    "@chainflip/utils": "2.2.0-alpha.4",
+    "@chainflip/utils": "2.2.0-alpha.5",
     "@chainflip/solana": "2.2.3",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,8 +20,8 @@
   "license": "ISC",
   "dependencies": {
     "@chainflip/bitcoin": "2.1.1",
-    "@chainflip/rpc": "2.2.0-alpha.8",
-    "@chainflip/utils": "2.2.0-alpha.3",
+    "@chainflip/rpc": "2.2.0-alpha.9",
+    "@chainflip/utils": "2.2.0-alpha.4",
     "@chainflip/solana": "2.2.3",
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.15.0",

--- a/packages/shared/src/consts.ts
+++ b/packages/shared/src/consts.ts
@@ -133,3 +133,5 @@ export const chainflipAssetToPriceAssetMap: InternalAssetMap<PriceAsset | null> 
   Trx: null,
   TrxUsdt: 'Usdt',
 };
+
+export const SUPPLY_POOL_BOOST_FEE_BPS = 5;

--- a/packages/shared/src/rpc/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/shared/src/rpc/__tests__/__snapshots__/index.test.ts.snap
@@ -36,6 +36,27 @@ exports[`getAllBoostPoolsDepth > retrieves the boost pools depth balance 1`] = `
 ]
 `;
 
+exports[`getAllSupplyPoolsDepth > retrieves the supply pools depth for a given asset 2`] = `
+[
+  [
+    "https://archive.perseverance.chainflip.io",
+    [
+      {
+        "id": "1",
+        "jsonrpc": "2.0",
+        "method": "cf_lending_pools",
+        "params": [
+          {
+            "asset": "BTC",
+            "chain": "Bitcoin",
+          },
+        ],
+      },
+    ],
+  ],
+]
+`;
+
 exports[`getFundingEnvironment > retrieves the funding environment 1`] = `
 [
   [

--- a/packages/shared/src/rpc/__tests__/index.test.ts
+++ b/packages/shared/src/rpc/__tests__/index.test.ts
@@ -12,7 +12,7 @@ import {
   getSwappingEnvironment,
   getIngressEgressEnvironment,
   getAllBoostPoolsDepth,
-  getSupplyPoolsDepth,
+  getAllSupplyPoolsDepth,
 } from '../index.js';
 
 const mockResponse = (data: any) => mockRpcResponse({ data });
@@ -437,11 +437,11 @@ describe('getAllBoostPoolsDepth', () => {
   });
 });
 
-describe('getSupplyPoolsDepth', () => {
+describe('getAllSupplyPoolsDepth', () => {
   it('retrieves the supply pools depth for a given asset', async () => {
     const spy = mockResponse(supplyPoolsDepth());
 
-    const result = await getSupplyPoolsDepth(
+    const result = await getAllSupplyPoolsDepth(
       { network: 'perseverance' },
       {
         chain: 'Bitcoin',
@@ -478,7 +478,7 @@ describe('getSupplyPoolsDepth', () => {
   it('returns an empty array when no supply pools exist', async () => {
     mockResponse(supplyPoolsDepth([]));
 
-    const result = await getSupplyPoolsDepth(
+    const result = await getAllSupplyPoolsDepth(
       { network: 'perseverance' },
       {
         chain: 'Bitcoin',

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -88,9 +88,9 @@ export const getAllBoostPoolsDepth = transform(createRequest('cf_boost_pools_dep
     ...rest,
   })),
 );
-export const getSupplyPoolsDepth = createRequest(`cf_lending_pools`);
+export const getAllSupplyPoolsDepth = createRequest(`cf_lending_pools`);
 
 export type BoostPoolsDepth = Awaited<ReturnType<typeof getAllBoostPoolsDepth>>;
-export type SupplyPoolsDepth = Awaited<ReturnType<typeof getSupplyPoolsDepth>>;
+export type SupplyPoolsDepth = Awaited<ReturnType<typeof getAllSupplyPoolsDepth>>;
 
 export const getSwapRateV3 = createRequest('cf_swap_rate_v3');

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -62,7 +62,7 @@
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/processor": "2.2.0-alpha.3",
     "@chainflip/rpc": "2.2.0-alpha.9",
-    "@chainflip/utils": "2.2.0-alpha.4",
+    "@chainflip/utils": "2.2.0-alpha.5",
     "@chainflip/redis": "2.2.0-alpha.1",
     "@chainflip/solana": "2.2.3",
     "@polkadot/api": "^15.10.2",

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -62,7 +62,7 @@
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/processor": "2.2.0-alpha.3",
     "@chainflip/rpc": "2.2.0-alpha.9",
-    "@chainflip/utils": "2.2.0-alpha.5",
+    "@chainflip/utils": "2.2.0-alpha.6",
     "@chainflip/redis": "2.2.0-alpha.1",
     "@chainflip/solana": "2.2.3",
     "@polkadot/api": "^15.10.2",

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -61,8 +61,8 @@
   "dependencies": {
     "@chainflip/bitcoin": "2.1.1",
     "@chainflip/processor": "2.2.0-alpha.3",
-    "@chainflip/rpc": "2.2.0-alpha.8",
-    "@chainflip/utils": "2.2.0-alpha.3",
+    "@chainflip/rpc": "2.2.0-alpha.9",
+    "@chainflip/utils": "2.2.0-alpha.4",
     "@chainflip/redis": "2.2.0-alpha.1",
     "@chainflip/solana": "2.2.3",
     "@polkadot/api": "^15.10.2",

--- a/packages/swap/src/routes/v2/__tests__/quote.test.ts
+++ b/packages/swap/src/routes/v2/__tests__/quote.test.ts
@@ -17,13 +17,14 @@ import {
   cfPoolDepth,
   environment,
   mockRpcResponse,
+  supplyPoolsDepth,
 } from '@/shared/tests/fixtures.js';
 import prisma from '../../../client.js';
 import env from '../../../config/env.js';
 import { getUsdValue } from '../../../pricing/checkPriceWarning.js';
 import Quoter from '../../../quoting/Quoter.js';
 import app from '../../../server.js';
-import { boostPoolsCache } from '../../../utils/boost.js';
+import { boostPoolsCache, supplyPoolsCache } from '../../../utils/boost.js';
 import { getTotalLiquidity } from '../../../utils/pools.js';
 
 vi.mock('../../../utils/pools', async (importOriginal) => {
@@ -98,6 +99,29 @@ const mockRpcs = ({
       });
     }
 
+    if (data.method === 'state_getRuntimeVersion') {
+      return Promise.resolve({
+        data: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            specName: 'chainflip-node',
+            implName: 'chainflip-node',
+            specVersion: 20200,
+            implVersion: 0,
+            authoringVersion: 1,
+            transactionVersion: 17,
+            stateVersion: 1,
+            apis: [],
+          },
+        },
+      });
+    }
+
+    if (data.method === 'cf_lending_pools') {
+      return Promise.resolve({ data: supplyPoolsDepth() });
+    }
+
     throw new Error(`unexpected axios call to ${url}: ${JSON.stringify(data)}`);
   });
 
@@ -129,6 +153,8 @@ describe('server', () => {
     mockRpcs({ ingressFee: hexEncodeNumber(2000000), egressFee: hexEncodeNumber(50000) });
     // eslint-disable-next-line dot-notation
     boostPoolsCache['store'].clear();
+    // eslint-disable-next-line dot-notation
+    supplyPoolsCache['store'].clear();
   });
 
   afterEach(() => {
@@ -1679,6 +1705,29 @@ describe('server', () => {
           });
         }
 
+        if (data.method === 'state_getRuntimeVersion') {
+          return Promise.resolve({
+            data: {
+              jsonrpc: '2.0',
+              id: 1,
+              result: {
+                specName: 'chainflip-node',
+                implName: 'chainflip-node',
+                specVersion: 20200,
+                implVersion: 0,
+                authoringVersion: 1,
+                transactionVersion: 17,
+                stateVersion: 1,
+                apis: [],
+              },
+            },
+          });
+        }
+
+        if (data.method === 'cf_lending_pools') {
+          return Promise.resolve({ data: supplyPoolsDepth() });
+        }
+
         throw new Error(`unexpected axios call to ${url}: ${JSON.stringify(data)}`);
       });
 
@@ -2242,6 +2291,29 @@ describe('server', () => {
           });
         }
 
+        if (data.method === 'state_getRuntimeVersion') {
+          return Promise.resolve({
+            data: {
+              jsonrpc: '2.0',
+              id: 1,
+              result: {
+                specName: 'chainflip-node',
+                implName: 'chainflip-node',
+                specVersion: 20200,
+                implVersion: 0,
+                authoringVersion: 1,
+                transactionVersion: 17,
+                stateVersion: 1,
+                apis: [],
+              },
+            },
+          });
+        }
+
+        if (data.method === 'cf_lending_pools') {
+          return Promise.resolve({ data: supplyPoolsDepth() });
+        }
+
         throw new Error(`unexpected axios call to ${url}: ${JSON.stringify(data)}`);
       });
 
@@ -2440,6 +2512,29 @@ describe('server', () => {
             return Promise.resolve({
               data: cfPoolDepth(),
             });
+          }
+
+          if (data.method === 'state_getRuntimeVersion') {
+            return Promise.resolve({
+              data: {
+                jsonrpc: '2.0',
+                id: 1,
+                result: {
+                  specName: 'chainflip-node',
+                  implName: 'chainflip-node',
+                  specVersion: 20200,
+                  implVersion: 0,
+                  authoringVersion: 1,
+                  transactionVersion: 17,
+                  stateVersion: 1,
+                  apis: [],
+                },
+              },
+            });
+          }
+
+          if (data.method === 'cf_lending_pools') {
+            return Promise.resolve({ data: supplyPoolsDepth() });
           }
 
           throw new Error(`unexpected axios call to ${url}: ${JSON.stringify(data)}`);

--- a/packages/swap/src/utils/__tests__/boost.test.ts
+++ b/packages/swap/src/utils/__tests__/boost.test.ts
@@ -1,54 +1,163 @@
-import { CfBoostPoolsDepthResponse } from '@chainflip/rpc/types';
-import { hexEncodeNumber } from '@chainflip/utils/number';
 import { describe, it, beforeEach, expect, vi } from 'vitest';
-import { mockRpcResponse } from '@/shared/tests/fixtures.js';
-import { boostPoolsCache, getBoostFeeBpsForAmount } from '../boost.js';
+import { boostPoolsCache, supplyPoolsCache, getBoostFeeBpsForAmount } from '../boost.js';
+import * as rpc from '../rpc.js';
 
-vi.mock('axios');
+vi.mock('../rpc.js');
+
+const boostPool = (tier: number, availableAmount: bigint) =>
+  ({ asset: 'Btc', tier, availableAmount }) as any;
+
+const supplyPool = (
+  availableAmount: bigint,
+  utilisationCap?: number | null,
+  totalAmount?: bigint,
+) =>
+  ({
+    ...(utilisationCap !== undefined && { utilisationCap }),
+    asset: { chain: 'Bitcoin', asset: 'BTC' },
+    availableAmount,
+    totalAmount: totalAmount ?? availableAmount,
+    utilisationRate: 0,
+    currentInterestRate: 100,
+    originationFee: 10,
+    liquidationFee: 5,
+    interestRateCurve: {
+      interestAtZeroUtilisation: 50,
+      junctionUtilisation: 80,
+      interestAtJunctionUtilisation: 75,
+      interestAtMaxUtilisation: 200,
+    },
+  }) as any;
 
 describe(getBoostFeeBpsForAmount, () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     // eslint-disable-next-line dot-notation
     boostPoolsCache['store'].clear();
+    // eslint-disable-next-line dot-notation
+    supplyPoolsCache['store'].clear();
   });
 
-  it.each([
-    [
-      BigInt(1e8),
-      [
-        { asset: 'BTC', chain: 'Bitcoin', tier: 10, available_amount: hexEncodeNumber(0) },
-        { asset: 'BTC', chain: 'Bitcoin', tier: 100, available_amount: hexEncodeNumber(1e8) },
-      ] as CfBoostPoolsDepthResponse,
-      { estimatedBoostFeeBps: 100, maxBoostFeeBps: 100 },
-    ],
-    [
-      BigInt(1e8),
-      [
-        { asset: 'BTC', chain: 'Bitcoin', tier: 10, available_amount: hexEncodeNumber(1e8) },
-        { asset: 'BTC', chain: 'Bitcoin', tier: 100, available_amount: hexEncodeNumber(0) },
-      ] as CfBoostPoolsDepthResponse,
-      { estimatedBoostFeeBps: 10, maxBoostFeeBps: 100 },
-    ],
-    [
-      BigInt(1e8),
-      [
-        { asset: 'BTC', chain: 'Bitcoin', tier: 5, available_amount: hexEncodeNumber(0.5e8) },
-        { asset: 'BTC', chain: 'Bitcoin', tier: 10, available_amount: hexEncodeNumber(0.5e8) },
-      ] as CfBoostPoolsDepthResponse,
-      { estimatedBoostFeeBps: 7, maxBoostFeeBps: 10 },
-    ],
-    [
-      BigInt(1e8),
-      [
-        { asset: 'BTC', chain: 'Bitcoin', tier: 10, available_amount: hexEncodeNumber(0.1e8) },
-        { asset: 'BTC', chain: 'Bitcoin', tier: 100, available_amount: hexEncodeNumber(0.9e8) },
-      ] as CfBoostPoolsDepthResponse,
-      { estimatedBoostFeeBps: 91, maxBoostFeeBps: 100 },
-    ],
-  ])('calculates boost fee for %s', async (ingressAmount, assetBoostPoolsDepth, boostBps) => {
-    mockRpcResponse({ data: { id: '1', jsonrpc: '2.0', result: assetBoostPoolsDepth } });
-    expect(await getBoostFeeBpsForAmount({ amount: ingressAmount, asset: 'Btc' })).toStrictEqual(
-      boostBps,
-    );
+  it('returns undefined estimatedBoostFeeBps and 0 maxBoostFeeBps for non-BTC asset', async () => {
+    expect(await getBoostFeeBpsForAmount({ amount: BigInt(1e8), asset: 'Eth' })).toStrictEqual({
+      estimatedBoostFeeBps: undefined,
+      maxBoostFeeBps: 0,
+    });
+  });
+
+  // TODO(2.2): Remove after all networks are upgraded
+  describe('pre-runtime 20200: 5, 15, 30 bps boost pools (no supply pools)', () => {
+    beforeEach(() => {
+      vi.mocked(rpc.getRuntimeVersion).mockResolvedValue({ specVersion: 20199 } as any);
+      vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([
+        boostPool(5, BigInt(1e8)),
+        boostPool(15, BigInt(0.5e8)),
+        boostPool(30, 0n),
+      ]);
+    });
+
+    it('does not call getSupplyPoolsDepth', async () => {
+      await getBoostFeeBpsForAmount({ amount: BigInt(0.5e8), asset: 'Btc' });
+
+      expect(rpc.getSupplyPoolsDepth).not.toHaveBeenCalled();
+    });
+
+    it('serves amount from cheapest (5 bps) pool', async () => {
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(0.5e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: 5,
+        maxBoostFeeBps: 30,
+      });
+    });
+
+    it('splits across 5 and 15 bps pools when 5 bps pool is insufficient', async () => {
+      // 1e8 from 5-bps pool, 0.5e8 from 15-bps pool → weighted average ≈ 8 bps
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(1.5e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: 8,
+        maxBoostFeeBps: 30,
+      });
+    });
+
+    it('returns undefined estimatedBoostFeeBps when boost pool liquidity is insufficient', async () => {
+      // Only 1.5e8 available across all boost pools, requesting 2e8
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(2e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: undefined,
+        maxBoostFeeBps: 30,
+      });
+    });
+  });
+
+  describe('post-runtime 20200: 5 bps boost pool + 5 bps supply pool', () => {
+    beforeEach(() => {
+      vi.mocked(rpc.getRuntimeVersion).mockResolvedValue({ specVersion: 20200 } as any);
+      vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([boostPool(5, BigInt(1e8))]);
+      vi.mocked(rpc.getSupplyPoolsDepth).mockResolvedValue([supplyPool(BigInt(1e8))]);
+    });
+
+    it('serves amount from the boost pool alone when it has sufficient liquidity', async () => {
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(0.5e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: 5,
+        maxBoostFeeBps: 5,
+      });
+    });
+
+    it('splits between boost and supply pool, both at 5 bps', async () => {
+      // 1e8 from 5-bps boost pool, 0.5e8 from 5-bps supply pool → still 5 bps flat
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(1.5e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: 5,
+        maxBoostFeeBps: 5,
+      });
+    });
+
+    it('returns undefined estimatedBoostFeeBps when total liquidity is insufficient', async () => {
+      // Only 2e8 available in total (1e8 boost + 1e8 supply), requesting 2.5e8
+      expect(await getBoostFeeBpsForAmount({ amount: BigInt(2.5e8), asset: 'Btc' })).toStrictEqual({
+        estimatedBoostFeeBps: undefined,
+        maxBoostFeeBps: 5,
+      });
+    });
+
+    describe('utilisationCap on supply pool', () => {
+      it('null utilisationCap uses totalAvailableAmount as the usable amount', async () => {
+        // Boost: 0.5e8, Supply: total=2e8, available=1e8, null cap
+        // borrowed=1e8, effective limit=2e8 (100%), usable = 2e8 - 1e8 = 1e8
+        vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([boostPool(5, BigInt(0.5e8))]);
+        vi.mocked(rpc.getSupplyPoolsDepth).mockResolvedValue([
+          supplyPool(BigInt(1e8), null, BigInt(2e8)),
+        ]);
+
+        // 0.5e8 from boost + 1e8 from supply → covers 1.5e8 at 5 bps flat
+        expect(
+          await getBoostFeeBpsForAmount({ amount: BigInt(1.5e8), asset: 'Btc' }),
+        ).toStrictEqual({ estimatedBoostFeeBps: 5, maxBoostFeeBps: 5 });
+      });
+
+      it('allows borrowing remaining cap capacity when cap is partially exhausted', async () => {
+        // Boost: 0.5e8, Supply: total=2e8, available=1.5e8, 75% cap
+        // borrowed=0.5e8, effective limit=1.5e8, usable = 1.5e8 - 0.5e8 = 1e8
+        vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([boostPool(5, BigInt(0.5e8))]);
+        vi.mocked(rpc.getSupplyPoolsDepth).mockResolvedValue([
+          supplyPool(BigInt(1.5e8), 750_000, BigInt(2e8)),
+        ]);
+
+        // 0.5e8 from boost + 1e8 from supply (remaining cap) → covers 1.5e8 at 5 bps flat
+        expect(
+          await getBoostFeeBpsForAmount({ amount: BigInt(1.5e8), asset: 'Btc' }),
+        ).toStrictEqual({ estimatedBoostFeeBps: 5, maxBoostFeeBps: 5 });
+      });
+
+      it('prevents further borrowing when utilisationCap is fully exhausted', async () => {
+        // Boost: 0.5e8, Supply: total=2e8, available=0.5e8, 75% cap
+        // borrowed=1.5e8, effective limit=1.5e8, usable = 1.5e8 - 1.5e8 = 0
+        vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([boostPool(5, BigInt(0.5e8))]);
+        vi.mocked(rpc.getSupplyPoolsDepth).mockResolvedValue([
+          supplyPool(BigInt(0.5e8), 750_000, BigInt(2e8)),
+        ]);
+
+        // 0.5e8 from boost + 0 from supply (cap exhausted) = 0.5e8 < 1.5e8 → undefined
+        expect(
+          await getBoostFeeBpsForAmount({ amount: BigInt(1.5e8), asset: 'Btc' }),
+        ).toStrictEqual({ estimatedBoostFeeBps: undefined, maxBoostFeeBps: 5 });
+      });
+    });
   });
 });

--- a/packages/swap/src/utils/__tests__/boost.test.ts
+++ b/packages/swap/src/utils/__tests__/boost.test.ts
@@ -48,7 +48,7 @@ describe(getBoostFeeBpsForAmount, () => {
   // TODO(2.2): Remove after all networks are upgraded
   describe('pre-runtime 20200: 5, 15, 30 bps boost pools (no supply pools)', () => {
     beforeEach(() => {
-      vi.mocked(rpc.getRuntimeVersion).mockResolvedValue({ specVersion: 20199 } as any);
+      vi.mocked(rpc.cachedGetRuntimeVersion).mockResolvedValue({ specVersion: 20199 } as any);
       vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([
         boostPool(5, BigInt(1e8)),
         boostPool(15, BigInt(0.5e8)),
@@ -88,7 +88,7 @@ describe(getBoostFeeBpsForAmount, () => {
 
   describe('post-runtime 20200: 5 bps boost pool + 5 bps supply pool', () => {
     beforeEach(() => {
-      vi.mocked(rpc.getRuntimeVersion).mockResolvedValue({ specVersion: 20200 } as any);
+      vi.mocked(rpc.cachedGetRuntimeVersion).mockResolvedValue({ specVersion: 20200 } as any);
       vi.mocked(rpc.getBoostPoolsDepth).mockResolvedValue([boostPool(5, BigInt(1e8))]);
       vi.mocked(rpc.getSupplyPoolsDepth).mockResolvedValue([supplyPool(BigInt(1e8))]);
     });

--- a/packages/swap/src/utils/__tests__/rpc.test.ts
+++ b/packages/swap/src/utils/__tests__/rpc.test.ts
@@ -119,22 +119,22 @@ describe(getSupplyPoolsDepth, () => {
 
 describe(getRuntimeVersion, () => {
   it('returns the runtime version with camelCased fields', async () => {
-    mockRpcResponse({
+    mockRpcResponse(async () => ({
       data: {
         jsonrpc: '2.0',
         id: 1,
         result: {
-          spec_name: 'chainflip-node',
-          impl_name: 'chainflip-node',
-          spec_version: 20200,
-          impl_version: 0,
-          authoring_version: 1,
-          transaction_version: 17,
-          state_version: 1,
+          specName: 'chainflip-node',
+          implName: 'chainflip-node',
+          specVersion: 20200,
+          implVersion: 0,
+          authoringVersion: 1,
+          transactionVersion: 17,
+          stateVersion: 1,
           apis: [],
         },
       },
-    });
+    }));
 
     const result = await getRuntimeVersion();
 

--- a/packages/swap/src/utils/__tests__/rpc.test.ts
+++ b/packages/swap/src/utils/__tests__/rpc.test.ts
@@ -1,8 +1,19 @@
 import HttpClient from '@chainflip/rpc/HttpClient';
 import { ChainAssetMap } from '@chainflip/utils/chainflip';
 import { describe, it, expect, vi } from 'vitest';
-import { boostPoolsDepth, environment, mockRpcResponse } from '@/shared/tests/fixtures.js';
-import { getBoostDelay, getBoostPoolsDepth, getLpBalances } from '../rpc.js';
+import {
+  boostPoolsDepth,
+  environment,
+  mockRpcResponse,
+  supplyPoolsDepth,
+} from '@/shared/tests/fixtures.js';
+import {
+  getBoostDelay,
+  getBoostPoolsDepth,
+  getLpBalances,
+  getRuntimeVersion,
+  getSupplyPoolsDepth,
+} from '../rpc.js';
 
 describe(getBoostPoolsDepth, () => {
   it('allows filtering by asset through all the boost pools and sorts the result', async () => {
@@ -64,5 +75,70 @@ describe(getBoostDelay, () => {
 
     expect(numBlocks).toBeDefined();
     expect(await getBoostDelay('Bitcoin')).toBe(numBlocks);
+  });
+});
+
+describe(getSupplyPoolsDepth, () => {
+  it('filters supply pools by asset and converts to RPC asset format', async () => {
+    mockRpcResponse(async () => ({ data: supplyPoolsDepth() }));
+
+    const result = await getSupplyPoolsDepth({ asset: 'Btc' });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "asset": {
+            "asset": "BTC",
+            "chain": "Bitcoin",
+          },
+          "availableAmount": 100000n,
+          "currentInterestRate": 100,
+          "interestRateCurve": {
+            "interestAtJunctionUtilisation": 75,
+            "interestAtMaxUtilisation": 200,
+            "interestAtZeroUtilisation": 50,
+            "junctionUtilisation": 80,
+          },
+          "liquidationFee": 5,
+          "originationFee": 10,
+          "totalAmount": 100000n,
+          "utilisationRate": 0,
+        },
+      ]
+    `);
+  });
+
+  it('fetches all supply pools when no asset is provided', async () => {
+    mockRpcResponse(async () => ({ data: supplyPoolsDepth() }));
+
+    const result = await getSupplyPoolsDepth({});
+
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe(getRuntimeVersion, () => {
+  it('returns the runtime version with camelCased fields', async () => {
+    mockRpcResponse({
+      data: {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          spec_name: 'chainflip-node',
+          impl_name: 'chainflip-node',
+          spec_version: 20200,
+          impl_version: 0,
+          authoring_version: 1,
+          transaction_version: 17,
+          state_version: 1,
+          apis: [],
+        },
+      },
+    });
+
+    const result = await getRuntimeVersion();
+
+    expect(result.specVersion).toBe(20200);
+    expect(result.specName).toBe('chainflip-node');
   });
 });

--- a/packages/swap/src/utils/__tests__/rpc.test.ts
+++ b/packages/swap/src/utils/__tests__/rpc.test.ts
@@ -11,7 +11,7 @@ import {
   getBoostDelay,
   getBoostPoolsDepth,
   getLpBalances,
-  getRuntimeVersion,
+  cachedGetRuntimeVersion,
   getSupplyPoolsDepth,
 } from '../rpc.js';
 
@@ -117,7 +117,7 @@ describe(getSupplyPoolsDepth, () => {
   });
 });
 
-describe(getRuntimeVersion, () => {
+describe(cachedGetRuntimeVersion, () => {
   it('returns the runtime version with camelCased fields', async () => {
     mockRpcResponse(async () => ({
       data: {
@@ -136,7 +136,7 @@ describe(getRuntimeVersion, () => {
       },
     }));
 
-    const result = await getRuntimeVersion();
+    const result = await cachedGetRuntimeVersion();
 
     expect(result.specVersion).toBe(20200);
     expect(result.specName).toBe('chainflip-node');

--- a/packages/swap/src/utils/boost.ts
+++ b/packages/swap/src/utils/boost.ts
@@ -1,5 +1,5 @@
 import { ChainflipAsset } from '@chainflip/utils/chainflip';
-import { calculateTotalEffectiveBorrowableAmount } from '@chainflip/utils/lending';
+import { calculateTotalEffectiveBorrowableAmount, ppmToBps } from '@chainflip/utils/lending';
 import { SUPPLY_POOL_BOOST_FEE_BPS } from '@/shared/consts.js';
 import { AsyncCacheMap } from '@/shared/dataStructures.js';
 import { ONE_IN_PIP, bigintMin, getPipAmountFromAmount } from '@/shared/functions.js';
@@ -48,7 +48,7 @@ export const getBoostFeeBpsForAmount = async ({
       poolAvailableAmount = calculateTotalEffectiveBorrowableAmount({
         totalAmount: poolDepth.totalAmount,
         totalAvailableAmount: poolDepth.availableAmount,
-        utilisationCap: poolDepth.utilisationCap,
+        utilisationCapBps: ppmToBps(poolDepth.utilisationCap ?? 1_000_000),
       });
     }
 

--- a/packages/swap/src/utils/boost.ts
+++ b/packages/swap/src/utils/boost.ts
@@ -1,5 +1,6 @@
 import { ChainflipAsset } from '@chainflip/utils/chainflip';
 import { calculateTotalEffectiveBorrowableAmount } from '@chainflip/utils/lending';
+import { SUPPLY_POOL_BOOST_FEE_BPS } from '@/shared/consts.js';
 import { AsyncCacheMap } from '@/shared/dataStructures.js';
 import { ONE_IN_PIP, bigintMin, getPipAmountFromAmount } from '@/shared/functions.js';
 import { getBoostPoolsDepth, getRuntimeVersion, getSupplyPoolsDepth } from './rpc.js';
@@ -15,7 +16,6 @@ export const supplyPoolsCache = new AsyncCacheMap({
   resetExpiryOnLookup: false,
   ttl: 6_000,
 });
-const SUPPLY_POOL_BOOST_FEE_BPS = 5;
 
 export const getBoostFeeBpsForAmount = async ({
   amount,
@@ -55,7 +55,7 @@ export const getBoostFeeBpsForAmount = async ({
     const amountToBeUsedFromPool = bigintMin(remainingAmount, poolAvailableAmount);
     feeAmount += getPipAmountFromAmount(
       amountToBeUsedFromPool,
-      'tier' in poolDepth ? poolDepth.tier : 5, // Supply pools have a fixed 5 bps fee for boost loans
+      'tier' in poolDepth ? poolDepth.tier : SUPPLY_POOL_BOOST_FEE_BPS, // Supply pools have a fixed fee for boost loans
     );
     remainingAmount -= amountToBeUsedFromPool;
 

--- a/packages/swap/src/utils/boost.ts
+++ b/packages/swap/src/utils/boost.ts
@@ -34,10 +34,8 @@ export const getBoostFeeBpsForAmount = async ({
 
   const maxBoostFeeBps = Math.max(
     0,
-    ...[
-      assetBoostPoolsDepth.map((pool) => pool.tier),
-      assetSupplyPoolsDepth.length > 0 ? SUPPLY_POOL_BOOST_FEE_BPS : 0, // Supply pools have a fixed 5 bps fee for boost loans
-    ].flat(),
+    ...assetBoostPoolsDepth.map((pool) => pool.tier),
+    assetSupplyPoolsDepth.length > 0 ? SUPPLY_POOL_BOOST_FEE_BPS : 0,
   );
   // TODO(2.2): Simplify logic by checking against total liquidity of both pools and calculating fee amount only once at the end
   for (const poolDepth of [assetBoostPoolsDepth, assetSupplyPoolsDepth].flat()) {

--- a/packages/swap/src/utils/boost.ts
+++ b/packages/swap/src/utils/boost.ts
@@ -3,7 +3,7 @@ import { calculateTotalEffectiveBorrowableAmount, ppmToBps } from '@chainflip/ut
 import { SUPPLY_POOL_BOOST_FEE_BPS } from '@/shared/consts.js';
 import { AsyncCacheMap } from '@/shared/dataStructures.js';
 import { ONE_IN_PIP, bigintMin, getPipAmountFromAmount } from '@/shared/functions.js';
-import { getBoostPoolsDepth, getRuntimeVersion, getSupplyPoolsDepth } from './rpc.js';
+import { cachedGetRuntimeVersion, getBoostPoolsDepth, getSupplyPoolsDepth } from './rpc.js';
 
 export const boostPoolsCache = new AsyncCacheMap({
   fetch: (asset: ChainflipAsset) => getBoostPoolsDepth({ asset }),
@@ -24,8 +24,9 @@ export const getBoostFeeBpsForAmount = async ({
   amount: bigint;
   asset: ChainflipAsset;
 }): Promise<{ estimatedBoostFeeBps: number | undefined; maxBoostFeeBps: number }> => {
-  if (asset !== 'Btc') return { estimatedBoostFeeBps: undefined, maxBoostFeeBps: 0 };
-  const { specVersion } = await getRuntimeVersion();
+  if (asset !== 'Btc' || amount === 0n)
+    return { estimatedBoostFeeBps: undefined, maxBoostFeeBps: 0 };
+  const { specVersion } = await cachedGetRuntimeVersion();
   const assetBoostPoolsDepth = await boostPoolsCache.get(asset);
   const assetSupplyPoolsDepth = specVersion >= 20200 ? await supplyPoolsCache.get(asset) : []; // TODO(2.2): Remove version check once all networks are upgraded
 

--- a/packages/swap/src/utils/boost.ts
+++ b/packages/swap/src/utils/boost.ts
@@ -1,13 +1,21 @@
 import { ChainflipAsset } from '@chainflip/utils/chainflip';
+import { calculateTotalEffectiveBorrowableAmount } from '@chainflip/utils/lending';
 import { AsyncCacheMap } from '@/shared/dataStructures.js';
 import { ONE_IN_PIP, bigintMin, getPipAmountFromAmount } from '@/shared/functions.js';
-import { getBoostPoolsDepth } from './rpc.js';
+import { getBoostPoolsDepth, getRuntimeVersion, getSupplyPoolsDepth } from './rpc.js';
 
 export const boostPoolsCache = new AsyncCacheMap({
   fetch: (asset: ChainflipAsset) => getBoostPoolsDepth({ asset }),
   resetExpiryOnLookup: false,
   ttl: 6_000,
 });
+
+export const supplyPoolsCache = new AsyncCacheMap({
+  fetch: (asset: ChainflipAsset) => getSupplyPoolsDepth({ asset }),
+  resetExpiryOnLookup: false,
+  ttl: 6_000,
+});
+const SUPPLY_POOL_BOOST_FEE_BPS = 5;
 
 export const getBoostFeeBpsForAmount = async ({
   amount,
@@ -17,24 +25,44 @@ export const getBoostFeeBpsForAmount = async ({
   asset: ChainflipAsset;
 }): Promise<{ estimatedBoostFeeBps: number | undefined; maxBoostFeeBps: number }> => {
   if (asset !== 'Btc') return { estimatedBoostFeeBps: undefined, maxBoostFeeBps: 0 };
-
+  const { specVersion } = await getRuntimeVersion();
   const assetBoostPoolsDepth = await boostPoolsCache.get(asset);
+  const assetSupplyPoolsDepth = specVersion >= 20200 ? await supplyPoolsCache.get(asset) : []; // TODO(2.2): Remove version check once all networks are upgraded
 
   let remainingAmount = amount;
   let feeAmount = 0n;
-  const maxBoostFeeBps = Math.max(0, ...assetBoostPoolsDepth.map((pool) => pool.tier));
 
-  for (const poolDepth of assetBoostPoolsDepth) {
-    const poolAvailableAmount = poolDepth.availableAmount;
+  const maxBoostFeeBps = Math.max(
+    0,
+    ...[
+      assetBoostPoolsDepth.map((pool) => pool.tier),
+      assetSupplyPoolsDepth.length > 0 ? SUPPLY_POOL_BOOST_FEE_BPS : 0, // Supply pools have a fixed 5 bps fee for boost loans
+    ].flat(),
+  );
+  // TODO(2.2): Simplify logic by checking against total liquidity of both pools and calculating fee amount only once at the end
+  for (const poolDepth of [assetBoostPoolsDepth, assetSupplyPoolsDepth].flat()) {
+    let poolAvailableAmount = poolDepth.availableAmount;
+
+    if ('utilisationCap' in poolDepth) {
+      // TODO(2.2): Document and simplify this logic by calculating the effective available amount in the RPC itself
+      poolAvailableAmount = calculateTotalEffectiveBorrowableAmount({
+        totalAmount: poolDepth.totalAmount,
+        totalAvailableAmount: poolDepth.availableAmount,
+        utilisationCap: poolDepth.utilisationCap,
+      });
+    }
 
     const amountToBeUsedFromPool = bigintMin(remainingAmount, poolAvailableAmount);
-    feeAmount += getPipAmountFromAmount(amountToBeUsedFromPool, poolDepth.tier);
+    feeAmount += getPipAmountFromAmount(
+      amountToBeUsedFromPool,
+      'tier' in poolDepth ? poolDepth.tier : 5, // Supply pools have a fixed 5 bps fee for boost loans
+    );
     remainingAmount -= amountToBeUsedFromPool;
 
     if (remainingAmount === 0n) break;
   }
 
-  // Not enough liquidity in the boost pools
+  // Not enough liquidity to boost the entire amount
   if (remainingAmount > 0) return { estimatedBoostFeeBps: undefined, maxBoostFeeBps };
 
   return {

--- a/packages/swap/src/utils/rpc.ts
+++ b/packages/swap/src/utils/rpc.ts
@@ -22,7 +22,7 @@ import {
   getAccountInfo as getAccountInfoRpc,
   getAllSupplyPoolsDepth,
   SupplyPoolsDepth,
-  getRuntimeVersion as getRuntimeVersionRpc,
+  getRuntimeVersion,
 } from '@/shared/rpc/index.js';
 import { validateSwapAmount as validateAmount } from '@/shared/rpc/utils.js';
 import { memoize } from './function.js';
@@ -198,6 +198,4 @@ export const getDefaultOracleProtectionValue = async (asset: BaseChainflipAsset)
   return readAssetValue(defaultOracleProtectionValue, asset);
 };
 
-export const getRuntimeVersion = () => getRuntimeVersionRpc(rpcConfig);
-
-export const cachedGetRuntimeVersion = memoize(getRuntimeVersion, 300_000);
+export const cachedGetRuntimeVersion = memoize(() => getRuntimeVersion(rpcConfig), 300_000);

--- a/packages/swap/src/utils/rpc.ts
+++ b/packages/swap/src/utils/rpc.ts
@@ -199,3 +199,5 @@ export const getDefaultOracleProtectionValue = async (asset: BaseChainflipAsset)
 };
 
 export const getRuntimeVersion = () => getRuntimeVersionRpc(rpcConfig);
+
+export const cachedGetRuntimeVersion = memoize(getRuntimeVersion, 300_000);

--- a/packages/swap/src/utils/rpc.ts
+++ b/packages/swap/src/utils/rpc.ts
@@ -20,6 +20,9 @@ import {
   getPoolDepth as getPoolDepthRpc,
   getAccounts as getAccountsRpc,
   getAccountInfo as getAccountInfoRpc,
+  getAllSupplyPoolsDepth,
+  SupplyPoolsDepth,
+  getRuntimeVersion as getRuntimeVersionRpc,
 } from '@/shared/rpc/index.js';
 import { validateSwapAmount as validateAmount } from '@/shared/rpc/utils.js';
 import { memoize } from './function.js';
@@ -158,6 +161,13 @@ export const getBoostPoolsDepth = async ({
   return allBoostPoolsDepth;
 };
 
+export const getSupplyPoolsDepth = async ({
+  asset,
+}: {
+  asset?: ChainflipAsset;
+}): Promise<SupplyPoolsDepth> =>
+  getAllSupplyPoolsDepth(rpcConfig, asset ? internalAssetToRpcAsset[asset] : undefined);
+
 export const getLpBalances = async <T extends string>(
   accountIds: Set<T> | T[],
 ): Promise<(readonly [T, InternalAssetMap<bigint>])[]> => {
@@ -187,3 +197,5 @@ export const getDefaultOracleProtectionValue = async (asset: BaseChainflipAsset)
 
   return readAssetValue(defaultOracleProtectionValue, asset);
 };
+
+export const getRuntimeVersion = () => getRuntimeVersionRpc(rpcConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,14 +124,14 @@ importers:
         specifier: 2.1.1
         version: 2.1.1(typescript@5.9.3)
       '@chainflip/rpc':
-        specifier: 2.2.0-alpha.8
-        version: 2.2.0-alpha.8
+        specifier: 2.2.0-alpha.9
+        version: 2.2.0-alpha.9
       '@chainflip/solana':
         specifier: 2.2.3
-        version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.3
-        version: 2.2.0-alpha.3
+        specifier: 2.2.0-alpha.5
+        version: 2.2.0-alpha.5
       '@ts-rest/core':
         specifier: ^3.52.1
         version: 3.52.1(@types/node@24.0.4)(zod@3.25.76)
@@ -143,7 +143,7 @@ importers:
         version: 9.3.0
       ethers:
         specifier: ^6.14.4
-        version: 6.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 6.14.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -158,14 +158,14 @@ importers:
         specifier: 2.1.1
         version: 2.1.1(typescript@5.9.3)
       '@chainflip/rpc':
-        specifier: 2.2.0-alpha.8
-        version: 2.2.0-alpha.8
+        specifier: 2.2.0-alpha.9
+        version: 2.2.0-alpha.9
       '@chainflip/solana':
         specifier: 2.2.3
-        version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.3
-        version: 2.2.0-alpha.3
+        specifier: 2.2.0-alpha.5
+        version: 2.2.0-alpha.5
       '@ts-rest/core':
         specifier: ^3.52.1
         version: 3.52.1(@types/node@24.0.4)(zod@3.25.76)
@@ -177,13 +177,13 @@ importers:
         version: 9.3.0
       ethers:
         specifier: ^6.14.4
-        version: 6.14.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 6.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ioredis:
         specifier: ^5.6.1
         version: 5.6.1
       ws:
         specifier: ^8.18.2
-        version: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 8.18.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -193,10 +193,10 @@ importers:
         version: 5.8.0
       '@ethersproject/providers':
         specifier: ^5.8.0
-        version: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.14.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.5.1(ethers@6.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -222,14 +222,14 @@ importers:
         specifier: 2.2.0-alpha.1
         version: 2.2.0-alpha.1
       '@chainflip/rpc':
-        specifier: 2.2.0-alpha.8
-        version: 2.2.0-alpha.8
+        specifier: 2.2.0-alpha.9
+        version: 2.2.0-alpha.9
       '@chainflip/solana':
         specifier: 2.2.3
         version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.3
-        version: 2.2.0-alpha.3
+        specifier: 2.2.0-alpha.5
+        version: 2.2.0-alpha.5
       '@polkadot/api':
         specifier: ^15.10.2
         version: 15.10.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -465,8 +465,8 @@ packages:
   '@chainflip/redis@2.2.0-alpha.1':
     resolution: {integrity: sha512-V9lmE2ojdl7wNfhob/LDa01iyJiVThG5nNEKhr0CmQyGAym2zGSIekPlZSVv241dNgIEs7ZMEHU3wNfy4M6d+Q==}
 
-  '@chainflip/rpc@2.2.0-alpha.8':
-    resolution: {integrity: sha512-GE8KTxsUqRFzQCFyP5Yh31eyBV/uQiHUv8cpnqCjnkksnMbDI7iQsgcn0/qi0QGosZSTF8yddTJ3NF24uHiu8w==}
+  '@chainflip/rpc@2.2.0-alpha.9':
+    resolution: {integrity: sha512-kpQiHn3oDLRnY+FcGxy1sY63iqkhvNglJ7On2woeXRoJ9nly3tTA7paIWDLcHycnzdTlNqCqp5a+UdLtURAoSQ==}
 
   '@chainflip/scale@1.11.0':
     resolution: {integrity: sha512-gLs2pARutz6JJSKth92TYQEHVWvwpavWNUARB9626t+QxlparHyL10t9XibD2X1sr+GLXWKj2q5qXOSGU8CICA==}
@@ -486,8 +486,8 @@ packages:
   '@chainflip/utils@2.2.0-alpha.2':
     resolution: {integrity: sha512-BqJH3V/gpN0sgvjhrbBCzpCJ/NqXxO4H4SBDC+ZqLFFxgAg0xQw1SP6zmY9vL/BJe1ukB/shE316qCJxFouUIA==}
 
-  '@chainflip/utils@2.2.0-alpha.3':
-    resolution: {integrity: sha512-IMfSN0ZIeC58oIcDh5k2mAwlIucfxb4KfGqoJY/OKt1dm0o+GiilVt8SS/GYf7AEDvv0/VgR/Blk0FlNLgPz/w==}
+  '@chainflip/utils@2.2.0-alpha.5':
+    resolution: {integrity: sha512-EMZrRu5fUdUB5Y7+gkYgmx5FbophTXUFCm7dbjCVSa7m/kJn00QyJTAaQO3j+B5QSUbmbhBLs3JoNqK71XU6Jg==}
 
   '@chevrotain/cst-dts-gen@10.5.0':
     resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
@@ -1448,56 +1448,67 @@ packages:
     resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.0':
     resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.0':
     resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.0':
     resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
     resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
     resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.0':
     resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.0':
     resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.0':
     resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.0':
     resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.0':
     resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.0':
     resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
@@ -6154,7 +6165,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chainflip/rpc@2.2.0-alpha.8':
+  '@chainflip/rpc@2.2.0-alpha.9':
     dependencies:
       '@chainflip/utils': 2.2.0-alpha.1
       zod: 3.25.76
@@ -6221,7 +6232,7 @@ snapshots:
       bignumber.js: 11.1.1
       date-fns: 4.1.0
 
-  '@chainflip/utils@2.2.0-alpha.3':
+  '@chainflip/utils@2.2.0-alpha.5':
     dependencies:
       '@date-fns/utc': 2.1.1
       '@noble/hashes': 2.2.0
@@ -6543,7 +6554,7 @@ snapshots:
     dependencies:
       '@ethersproject/logger': 5.8.0
 
-  '@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abstract-provider': 5.8.0
       '@ethersproject/abstract-signer': 5.8.0
@@ -6564,7 +6575,7 @@ snapshots:
       '@ethersproject/transactions': 5.8.0
       '@ethersproject/web': 5.8.0
       bech32: 1.1.4
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7841,9 +7852,9 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@typechain/ethers-v6@0.5.1(ethers@6.14.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@typechain/ethers-v6@0.5.1(ethers@6.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      ethers: 6.14.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ethers: 6.14.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.9.3)
       typechain: 8.3.2(typescript@5.9.3)
@@ -12897,10 +12908,10 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
-  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
+      utf-8-validate: 5.0.10
 
   ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: 2.2.3
         version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.5
-        version: 2.2.0-alpha.5
+        specifier: 2.2.0-alpha.6
+        version: 2.2.0-alpha.6
       '@ts-rest/core':
         specifier: ^3.52.1
         version: 3.52.1(@types/node@24.0.4)(zod@3.25.76)
@@ -164,8 +164,8 @@ importers:
         specifier: 2.2.3
         version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.5
-        version: 2.2.0-alpha.5
+        specifier: 2.2.0-alpha.6
+        version: 2.2.0-alpha.6
       '@ts-rest/core':
         specifier: ^3.52.1
         version: 3.52.1(@types/node@24.0.4)(zod@3.25.76)
@@ -228,8 +228,8 @@ importers:
         specifier: 2.2.3
         version: 2.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
-        specifier: 2.2.0-alpha.5
-        version: 2.2.0-alpha.5
+        specifier: 2.2.0-alpha.6
+        version: 2.2.0-alpha.6
       '@polkadot/api':
         specifier: ^15.10.2
         version: 15.10.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -486,8 +486,8 @@ packages:
   '@chainflip/utils@2.2.0-alpha.2':
     resolution: {integrity: sha512-BqJH3V/gpN0sgvjhrbBCzpCJ/NqXxO4H4SBDC+ZqLFFxgAg0xQw1SP6zmY9vL/BJe1ukB/shE316qCJxFouUIA==}
 
-  '@chainflip/utils@2.2.0-alpha.5':
-    resolution: {integrity: sha512-EMZrRu5fUdUB5Y7+gkYgmx5FbophTXUFCm7dbjCVSa7m/kJn00QyJTAaQO3j+B5QSUbmbhBLs3JoNqK71XU6Jg==}
+  '@chainflip/utils@2.2.0-alpha.6':
+    resolution: {integrity: sha512-O65ZOo74NdYvQdkozWwwL+pgyTE6EkIRugZrBe7OrFX9h608bj4kiZUkuANqIbNanxuMUCXtP5HSHraXS8LjfA==}
 
   '@chevrotain/cst-dts-gen@10.5.0':
     resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
@@ -6232,7 +6232,7 @@ snapshots:
       bignumber.js: 11.1.1
       date-fns: 4.1.0
 
-  '@chainflip/utils@2.2.0-alpha.5':
+  '@chainflip/utils@2.2.0-alpha.6':
     dependencies:
       '@date-fns/utc': 2.1.1
       '@noble/hashes': 2.2.0


### PR DESCRIPTION
> We need to start including the supply liquidity (as boost) in the Quoter when determining the:
> - boost fee bps estimation - should be a static 5 as we are removing all other pools
> - total boost liquidity - should use supply pools too and consider the utilisation caps
> - swapping frontend need to use updated getBoostLiquidity SDK method which includes supply positions

This is backwards compatible.