### PR TITLE
chore(swap): use price asset map from utils

### DIFF
--- a/packages/shared/src/consts.ts
+++ b/packages/shared/src/consts.ts
@@ -1,9 +1,4 @@
-import {
-  ChainflipChain,
-  ChainflipNetwork,
-  InternalAssetMap,
-  type PriceAsset,
-} from '@chainflip/utils/chainflip';
+import { ChainflipChain, ChainflipNetwork } from '@chainflip/utils/chainflip';
 
 const ETHEREUM_EVM_CHAIN_ID: Record<ChainflipNetwork, number> = {
   backspin: 10997, // backspin ethereum
@@ -134,28 +129,5 @@ export const MIN_TICK = -887272;
 export const MAX_TICK = -MIN_TICK;
 
 export const FULL_TICK_RANGE = { start: MIN_TICK, end: MAX_TICK };
-
-export const chainflipAssetToPriceAssetMap: InternalAssetMap<PriceAsset | null> = {
-  Btc: 'Btc',
-  Eth: 'Eth',
-  Sol: 'Sol',
-  Usdc: 'Usdc',
-  Usdt: 'Usdt',
-  Wbtc: null,
-  ArbUsdc: 'Usdc',
-  ArbUsdt: 'Usdt',
-  ArbEth: 'Eth',
-  SolUsdc: 'Usdc',
-  SolUsdt: 'Usdt',
-  Flip: null,
-  HubDot: null,
-  HubUsdc: null,
-  HubUsdt: null,
-  Trx: null,
-  TrxUsdt: 'Usdt',
-  Bnb: null,
-  BscUsdt: null, // Binance Bridged USDT is an un-official (yet most popular) version of the USDT asset.
-  Cbbtc: null,
-};
 
 export const SUPPLY_POOL_BOOST_FEE_BPS = 5;

--- a/packages/swap/src/handlers/__tests__/__snapshots__/networkInfo.test.ts.snap
+++ b/packages/swap/src/handlers/__tests__/__snapshots__/networkInfo.test.ts.snap
@@ -153,7 +153,7 @@ exports[`networkStatus > checks the chain's safe mode (deposit_channel_creation_
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -162,7 +162,7 @@ exports[`networkStatus > checks the chain's safe mode (deposit_channel_creation_
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -341,7 +341,7 @@ exports[`networkStatus > checks the chain's safe mode (deposit_channel_witnessin
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -350,7 +350,7 @@ exports[`networkStatus > checks the chain's safe mode (deposit_channel_witnessin
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -529,7 +529,7 @@ exports[`networkStatus > checks the chain's safe mode (vault_deposit_witnessing_
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -538,7 +538,7 @@ exports[`networkStatus > checks the chain's safe mode (vault_deposit_witnessing_
       "depositChannelCreationEnabled": false,
       "depositChannelDepositsEnabled": false,
       "egressEnabled": false,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": false,
     },
     {
@@ -717,7 +717,7 @@ exports[`networkStatus > returns everything when possible (default) 1`] = `
       "depositChannelCreationEnabled": true,
       "depositChannelDepositsEnabled": true,
       "egressEnabled": true,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": true,
     },
     {
@@ -726,7 +726,7 @@ exports[`networkStatus > returns everything when possible (default) 1`] = `
       "depositChannelCreationEnabled": true,
       "depositChannelDepositsEnabled": true,
       "egressEnabled": true,
-      "livePriceProtectionEnabled": false,
+      "livePriceProtectionEnabled": true,
       "vaultSwapDepositsEnabled": true,
     },
     {

--- a/packages/swap/src/handlers/__tests__/networkInfo.test.ts
+++ b/packages/swap/src/handlers/__tests__/networkInfo.test.ts
@@ -257,7 +257,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -266,7 +266,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -451,7 +451,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -460,7 +460,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -646,7 +646,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -655,7 +655,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -841,7 +841,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -850,7 +850,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1055,7 +1055,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1064,7 +1064,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1252,7 +1252,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1261,7 +1261,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1449,7 +1449,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {
@@ -1458,7 +1458,7 @@ describe('networkStatus', () => {
             "depositChannelCreationEnabled": false,
             "depositChannelDepositsEnabled": false,
             "egressEnabled": false,
-            "livePriceProtectionEnabled": false,
+            "livePriceProtectionEnabled": true,
             "vaultSwapDepositsEnabled": false,
           },
           {

--- a/packages/swap/src/handlers/networkInfo.ts
+++ b/packages/swap/src/handlers/networkInfo.ts
@@ -1,10 +1,13 @@
 import { HttpClient } from '@chainflip/rpc';
 import { RpcMethod, RpcRequest, RpcResult } from '@chainflip/rpc/common';
-import { assetConstants, getInternalAsset } from '@chainflip/utils/chainflip';
+import {
+  assetConstants,
+  chainflipAssetToPriceAssetMap,
+  getInternalAsset,
+} from '@chainflip/utils/chainflip';
 import { uncapitalize } from '@chainflip/utils/string';
 import { z } from 'zod';
 import type { NetworkInfo } from '@/shared/api/networkInfo.js';
-import { chainflipAssetToPriceAssetMap } from '@/shared/consts.js';
 import { MultiCache, Fetcher } from '@/shared/dataStructures.js';
 import { isNotNullish } from '@/shared/guards.js';
 import env from '../config/env.js';


### PR DESCRIPTION
Uses `chainflipAssetToPriceAssetMap` from utils.