### PR TITLE
chore(swap): handle new depositDetails schema in event handlers [WEB-3783]

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@chainflip/bitcoin": "2.3.0-dev.1",
-    "@chainflip/processor": "2.3.0-dev.4",
+    "@chainflip/processor": "2.3.1",
     "@chainflip/rpc": "2.3.0-dev.5",
     "@chainflip/utils": "2.3.0-dev.5",
     "@chainflip/redis": "2.3.0-dev.1",

--- a/packages/swap/src/event-handlers/__tests__/common.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/common.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getDepositTxRef } from '../common.js';
+
+describe(getDepositTxRef, () => {
+  it('builds an assethub ref from the spec 230 deposit details', () => {
+    expect(
+      getDepositTxRef({
+        chain: 'Assethub',
+        data: { blockNumber: 9876543, extrinsicIndex: 2 },
+      }),
+    ).toBe('9876543-2');
+  });
+
+  it('prefers the spec 230 deposit details over the event block height', () => {
+    expect(
+      getDepositTxRef({ chain: 'Assethub', data: { blockNumber: 9876543, extrinsicIndex: 2 } }, 111n),
+    ).toBe('9876543-2');
+  });
+
+  it('builds an assethub ref from a legacy extrinsic index and the event block height', () => {
+    expect(getDepositTxRef({ chain: 'Assethub', data: 2 }, 9876543n)).toBe('9876543-2');
+  });
+
+  it('cannot build a legacy assethub ref without the event block height', () => {
+    expect(getDepositTxRef({ chain: 'Assethub', data: 2 })).toBeUndefined();
+  });
+});

--- a/packages/swap/src/event-handlers/__tests__/common.test.ts
+++ b/packages/swap/src/event-handlers/__tests__/common.test.ts
@@ -13,7 +13,10 @@ describe(getDepositTxRef, () => {
 
   it('prefers the spec 230 deposit details over the event block height', () => {
     expect(
-      getDepositTxRef({ chain: 'Assethub', data: { blockNumber: 9876543, extrinsicIndex: 2 } }, 111n),
+      getDepositTxRef(
+        { chain: 'Assethub', data: { blockNumber: 9876543, extrinsicIndex: 2 } },
+        111n,
+      ),
     ).toBe('9876543-2');
   });
 

--- a/packages/swap/src/event-handlers/common.ts
+++ b/packages/swap/src/event-handlers/common.ts
@@ -1,10 +1,11 @@
 import * as bitcoin from '@chainflip/bitcoin';
 import { arbitrumIngressEgressDepositFinalised } from '@chainflip/processor/11200/arbitrumIngressEgress/depositFinalised';
-import { assethubIngressEgressDepositFinalised } from '@chainflip/processor/11200/assethubIngressEgress/depositFinalised';
+import { assethubIngressEgressDepositFinalised as assethubDepositFinalised11200 } from '@chainflip/processor/11200/assethubIngressEgress/depositFinalised';
 import { bitcoinIngressEgressDepositFinalised } from '@chainflip/processor/11200/bitcoinIngressEgress/depositFinalised';
 import { ethereumIngressEgressDepositFinalised } from '@chainflip/processor/11200/ethereumIngressEgress/depositFinalised';
 import { solanaIngressEgressDepositFinalised } from '@chainflip/processor/11200/solanaIngressEgress/depositFinalised';
 import { tronIngressEgressDepositFinalised } from '@chainflip/processor/220/tronIngressEgress/depositFinalised';
+import { assethubIngressEgressDepositFinalised as assethubDepositFinalised230 } from '@chainflip/processor/230/assethubIngressEgress/depositFinalised';
 import { bscIngressEgressDepositFinalised } from '@chainflip/processor/230/bscIngressEgress/depositFinalised';
 import { cfChainsAddressForeignChainAddress } from '@chainflip/processor/230/common';
 import * as base58 from '@chainflip/utils/base58';
@@ -92,7 +93,9 @@ export type DepositDetailsData = {
       Ethereum: z.output<typeof ethereumIngressEgressDepositFinalised>;
       Arbitrum: z.output<typeof arbitrumIngressEgressDepositFinalised>;
       Solana: z.output<typeof solanaIngressEgressDepositFinalised> | { depositDetails: undefined };
-      Assethub: z.output<typeof assethubIngressEgressDepositFinalised>;
+      Assethub:
+        | z.output<typeof assethubDepositFinalised11200>
+        | z.output<typeof assethubDepositFinalised230>;
       Tron: z.output<typeof tronIngressEgressDepositFinalised>;
       Bsc: z.output<typeof bscIngressEgressDepositFinalised>;
     }[C]['depositDetails'];
@@ -118,12 +121,19 @@ export const getDepositTxRef = (
     }
     case 'Bitcoin':
       return formatTxRef({ chain: depositDetails.chain, data: depositDetails.data.id.txId });
-    case 'Assethub':
+    case 'Assethub': {
+      const { data } = depositDetails;
+      // spec 230 replaced the bare extrinsic index with a { blockNumber, extrinsicIndex } pair,
+      // which lets us build a ref even when the event carries no block height
+      if (typeof data === 'object') return formatTxRef({ chain: depositDetails.chain, data });
+
+      // TODO(2.3): Remove this once we no longer support spec 220
       if (blockHeight === undefined) return undefined;
       return formatTxRef({
         chain: depositDetails.chain,
-        data: { blockNumber: Number(blockHeight), extrinsicIndex: depositDetails.data },
+        data: { blockNumber: Number(blockHeight), extrinsicIndex: data },
       });
+    }
     case 'Solana':
       return undefined;
     default:

--- a/packages/swap/src/event-handlers/common.ts
+++ b/packages/swap/src/event-handlers/common.ts
@@ -125,7 +125,7 @@ export const getDepositTxRef = (
       const { data } = depositDetails;
       // spec 230 replaced the bare extrinsic index with a { blockNumber, extrinsicIndex } pair,
       // which lets us build a ref even when the event carries no block height
-      if (typeof data === 'object') return formatTxRef({ chain: depositDetails.chain, data });
+      if (typeof data !== 'number') return formatTxRef({ chain: depositDetails.chain, data });
 
       // TODO(2.3): Remove this once we no longer support spec 220
       if (blockHeight === undefined) return undefined;

--- a/packages/swap/src/event-handlers/ingress-egress/transactionRejectedByBroker.ts
+++ b/packages/swap/src/event-handlers/ingress-egress/transactionRejectedByBroker.ts
@@ -2,8 +2,9 @@ import { solanaIngressEgressTransactionRejectedByBroker } from '@chainflip/proce
 import { arbitrumIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/170/arbitrumIngressEgress/transactionRejectedByBroker';
 import { bitcoinIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/170/bitcoinIngressEgress/transactionRejectedByBroker';
 import { ethereumIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/170/ethereumIngressEgress/transactionRejectedByBroker';
-import { assethubIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/190/assethubIngressEgress/transactionRejectedByBroker';
+import { assethubIngressEgressTransactionRejectedByBroker as assethubSchema190 } from '@chainflip/processor/190/assethubIngressEgress/transactionRejectedByBroker';
 import { tronIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/220/tronIngressEgress/transactionRejectedByBroker';
+import { assethubIngressEgressTransactionRejectedByBroker as assethubSchema230 } from '@chainflip/processor/230/assethubIngressEgress/transactionRejectedByBroker';
 import { bscIngressEgressTransactionRejectedByBroker } from '@chainflip/processor/230/bscIngressEgress/transactionRejectedByBroker';
 import * as base58 from '@chainflip/utils/base58';
 import { hexToBytes } from '@chainflip/utils/bytes';
@@ -33,7 +34,7 @@ const schemaMap = {
     ...args,
     txId: { chain: 'Solana' as const, data: args.txId },
   })),
-  Assethub: assethubIngressEgressTransactionRejectedByBroker.transform((args) => ({
+  Assethub: z.union([assethubSchema230.strict(), assethubSchema190.strict()]).transform((args) => ({
     ...args,
     txId: { chain: 'Assethub' as const, data: args.txId },
   })),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: 2.3.0-dev.1
         version: 2.3.0-dev.1(typescript@5.9.3)
       '@chainflip/processor':
-        specifier: 2.3.0-dev.4
-        version: 2.3.0-dev.4
+        specifier: 2.3.1
+        version: 2.3.1
       '@chainflip/redis':
         specifier: 2.3.0-dev.1
         version: 2.3.0-dev.1
@@ -427,8 +427,8 @@ packages:
   '@chainflip/bitcoin@2.3.0-dev.1':
     resolution: {integrity: sha512-Srg+QfP6U2jDrQ/1q/lTgJHY0oCLCZc9InkqIqRPkVR8H0gkXoSX4uLQLyvfC9O9sE5i3qcXslASb/7eiSBxEQ==}
 
-  '@chainflip/processor@2.3.0-dev.4':
-    resolution: {integrity: sha512-HqHUkwv+T2pJjqWu10O46whL8szLZ9FMQ6+pakQpHzgRugHFQ/s2/fO3/G8WYYzE/3u3UqJ9c6HTF8yYU0wGnA==}
+  '@chainflip/processor@2.3.1':
+    resolution: {integrity: sha512-WYR2sYtlNA5EJmOQVf1vjVJT3FeGEwKSrv687UpRYyxEg4m9fI5SOe8qYA9udqsxckAd5CrT2WjkpZVgU2YaJw==}
 
   '@chainflip/redis@2.3.0-dev.1':
     resolution: {integrity: sha512-F9R6ND+TBpqo174g21S3sztoBj2oHyHjyZ74NJZ++ZLus8puFMePzY0YIfLlF6vXGzxQiZSpjOKHupLvDE6YhA==}
@@ -5736,7 +5736,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@chainflip/processor@2.3.0-dev.4':
+  '@chainflip/processor@2.3.1':
     dependencies:
       '@chainflip/rpc': 2.3.0-dev.4
       '@chainflip/utils': 2.3.0-dev.4


### PR DESCRIPTION
CI will fail because the @chainflip/processor is not released yet on npm.