### PR TITLE
chore(revert): assert that srcAsset and destAsset are not the same asset (#1633)

### DIFF
--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -44,36 +44,4 @@ describe('quoteQuerySchema', () => {
       }),
     ).not.toThrowError();
   });
-
-  it('throws if the source and destination assets are the same', () => {
-    expect(() =>
-      quoteQuerySchema.parse({
-        srcChain: 'Ethereum',
-        srcAsset: 'FLIP',
-        destChain: 'Ethereum',
-        destAsset: 'FLIP',
-        amount: '1000000000000',
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      [ZodError: [
-        {
-          "message": "srcAsset and destAsset cannot be the same",
-          "code": "custom",
-          "path": []
-        }
-      ]]
-    `);
-  });
-
-  it('allows the same asset on different chains', () => {
-    expect(() =>
-      quoteQuerySchema.parse({
-        srcChain: 'Ethereum',
-        srcAsset: 'USDC',
-        destChain: 'Arbitrum',
-        destAsset: 'USDC',
-        amount: '1000000000000',
-      }),
-    ).not.toThrowError();
-  });
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -6,7 +6,6 @@ import {
 } from '@chainflip/utils/chainflip';
 import { hexEncodeNumber } from '@chainflip/utils/number';
 import { z } from 'zod';
-import { isNotNullish } from './guards.js';
 import {
   chain,
   hexStringWithMaxByteSize,
@@ -65,15 +64,6 @@ export const quoteQuerySchema = z
     if (destAsset === null) {
       ctx.addIssue({
         message: `invalid asset and chain combination: ${JSON.stringify({ asset: args.destAsset, chain: args.destChain })}`,
-        code: z.ZodIssueCode.custom,
-      });
-
-      hadError = true;
-    }
-
-    if (isNotNullish(srcAsset) && isNotNullish(destAsset) && srcAsset === destAsset) {
-      ctx.addIssue({
-        message: `srcAsset and destAsset cannot be the same`,
         code: z.ZodIssueCode.custom,
       });
 


### PR DESCRIPTION
This reverts commit 2bd10e8b4954759810040c3a54d672c21767c23b.

Seems like there is a use case for same asset swaps, so reverting this.