### PR TITLE
fix(sdk): ss58 encode assethub creation channels

### DIFF
--- a/packages/shared/src/__tests__/broker.test.ts
+++ b/packages/shared/src/__tests__/broker.test.ts
@@ -1642,3 +1642,30 @@ describe(broker.requestCfParametersEncoding, () => {
     expect(result).toStrictEqual('0x1234');
   });
 });
+
+describe(broker.formatBrokerDepositAddress, () => {
+  it('ss58 encodes hex encoded Assethub addresses', () => {
+    expect(
+      broker.formatBrokerDepositAddress(
+        'Assethub',
+        '0xb72845b75b44e7e2ee29a390e9cf2e71291f2a1823299eedf5d016662fdb96cf',
+      ),
+    ).toBe('1599j8DFFZutdkvmxe81QNCpjNWAmmLD5pHSYph6gPVbp6av');
+  });
+
+  it('leaves already encoded Assethub addresses alone', () => {
+    expect(
+      broker.formatBrokerDepositAddress(
+        'Assethub',
+        '1599j8DFFZutdkvmxe81QNCpjNWAmmLD5pHSYph6gPVbp6av',
+      ),
+    ).toBe('1599j8DFFZutdkvmxe81QNCpjNWAmmLD5pHSYph6gPVbp6av');
+  });
+
+  it.each(['Ethereum', 'Arbitrum', 'Bitcoin', 'Solana', 'Tron', 'Bsc'] as const)(
+    'returns %s addresses as they come',
+    (chain) => {
+      expect(broker.formatBrokerDepositAddress(chain, '0xcafebabe')).toBe('0xcafebabe');
+    },
+  );
+});

--- a/packages/shared/src/broker.ts
+++ b/packages/shared/src/broker.ts
@@ -2,7 +2,11 @@ import { HttpClient } from '@chainflip/rpc';
 import { AssetAndChain } from '@chainflip/rpc/parsers';
 import { unreachable } from '@chainflip/utils/assertion';
 import { bytesToHex } from '@chainflip/utils/bytes';
-import { ChainflipNetwork, UncheckedAssetAndChain } from '@chainflip/utils/chainflip';
+import {
+  ChainflipChain,
+  ChainflipNetwork,
+  UncheckedAssetAndChain,
+} from '@chainflip/utils/chainflip';
 import * as ss58 from '@chainflip/utils/ss58';
 import { isHex } from '@chainflip/utils/string';
 import { priceX128ToPrice } from '@chainflip/utils/tickMath';
@@ -195,6 +199,24 @@ export const getVaultSwapParameterEncodingRequestSchema = (network: ChainflipNet
       return { ...data, extraParams };
     });
 
+export const formatBrokerDepositAddress = (chain: ChainflipChain, address: string): string => {
+  switch (chain) {
+    case 'Assethub':
+      return isHex(address) ? ss58.encode({ data: address, ss58Format: DOT_PREFIX }) : address;
+    case 'Ethereum':
+    case 'Arbitrum':
+    case 'Bitcoin':
+    case 'Solana':
+    case 'Tron':
+    case 'Bsc':
+      // these addresses come properly formatted
+      return address;
+    default:
+      // TODO remove casting to never when polkadot chain is fully removed
+      return unreachable(chain as never, 'unexpected chain');
+  }
+};
+
 export async function requestSwapDepositAddress(
   request: DepositAddressRequest,
   opts: { url: string },
@@ -217,24 +239,7 @@ export async function requestSwapDepositAddress(
     params.dcaParams,
   );
 
-  switch (params.srcAsset.chain) {
-    case 'Assethub':
-      if (isHex(response.address)) {
-        response.address = ss58.encode({ data: response.address, ss58Format: DOT_PREFIX });
-      }
-      break;
-    case 'Ethereum':
-    case 'Arbitrum':
-    case 'Bitcoin':
-    case 'Solana':
-    case 'Tron':
-    case 'Bsc':
-      // these addresses come properly formatted
-      break;
-    default:
-      // TODO remove casting to never when polkadot chain is fully removed
-      return unreachable(params.srcAsset as never, 'unexpected chain');
-  }
+  response.address = formatBrokerDepositAddress(params.srcAsset.chain, response.address);
 
   return transformKeysToCamelCase(response);
 }

--- a/packages/swap/src/handlers/openAccountCreationDepositChannel.ts
+++ b/packages/swap/src/handlers/openAccountCreationDepositChannel.ts
@@ -3,6 +3,7 @@ import { getInternalAsset } from '@chainflip/utils/chainflip';
 import { z } from 'zod';
 import { getAccountCreationDepositChannelSchema } from '@/shared/api/openAccountCreationDepositChannel.js';
 import { DepositChannelInfo } from '@/shared/api/openSwapDepositChannel.js';
+import { formatBrokerDepositAddress } from '@/shared/broker.js';
 import prisma from '../client.js';
 import env from '../config/env.js';
 import { calculateExpiryTime } from '../utils/function.js';
@@ -41,7 +42,7 @@ export const openAccountCreationDepositChannel = async (
       asset: getInternalAsset(params.asset),
       chain: params.asset.chain,
       channelId: result.channel_id,
-      depositAddress: result.address,
+      depositAddress: formatBrokerDepositAddress(params.asset.chain, result.address),
       createdAt: new Date(),
       maxBoostFeeBps: params.boostFeeBps,
       depositChainExpiryBlock: result.deposit_chain_expiry_block,

--- a/packages/swap/src/routes/__tests__/api.test.ts
+++ b/packages/swap/src/routes/__tests__/api.test.ts
@@ -1018,4 +1018,54 @@ describe('openAccountCreationDepositChannel', () => {
     `,
     );
   });
+
+  it('ss58 encodes the hex encoded address returned for Assethub', async () => {
+    await prisma.chainTracking.create({
+      data: {
+        chain: 'Assethub',
+        height: 27000n,
+        blockTrackedAt: new Date('2023-11-09T10:00:00.000Z'),
+        eventWitnessedBlock: 1,
+      },
+    });
+
+    const response: ChannelInfo = {
+      issued_block: 53948,
+      channel_id: 3,
+      address: '0xb72845b75b44e7e2ee29a390e9cf2e71291f2a1823299eedf5d016662fdb96cf',
+      requested_for: 'cFHsUq1uK5opJudRDczt7w4baiRDHR6Kdezw77u2JnRnCGKcs',
+      deposit_chain_expiry_block: 27208n,
+      channel_opening_fee: 0n,
+      refund_address: '15DQWnuLk3QbeYnUE7R5d35u3JXgPt6VxoJtZxa2xYHcQZue',
+    };
+
+    vi.spyOn(HttpClient.prototype, 'sendRequest').mockResolvedValueOnce(response);
+
+    const result = await client.openAccountCreationDepositChannel({
+      body: {
+        asset: { asset: 'DOT', chain: 'Assethub' },
+        refundAddress: '15DQWnuLk3QbeYnUE7R5d35u3JXgPt6VxoJtZxa2xYHcQZue',
+        signatureData: {
+          Ethereum: {
+            signature: '0x1234567890',
+            signer: '0x10C6E9530F1C1AF873a391030a1D9E8ed0630D26',
+            sigType: 'Eip712',
+          },
+        },
+        transactionMetadata: {
+          nonce: 0,
+          expiryBlock: 55000,
+        },
+        boostFeeBps: 30,
+      },
+    });
+
+    expect(result.status).toBe(201);
+    expect(result.body).toMatchObject({
+      depositAddress: '1599j8DFFZutdkvmxe81QNCpjNWAmmLD5pHSYph6gPVbp6av',
+    });
+    expect(await prisma.accountCreationDepositChannel.findFirst()).toMatchObject({
+      depositAddress: '1599j8DFFZutdkvmxe81QNCpjNWAmmLD5pHSYph6gPVbp6av',
+    });
+  });
 });


### PR DESCRIPTION
Assethub account creation deposit addresses were previously not properly ss58 encoded before stored in the DB.